### PR TITLE
feat(5.1): payment processor compliance pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,4 +100,13 @@ temp/
 .claude/settings.local.json
 
 # Personal planning — never push to GitHub
-marketing/
+/marketing/
+
+# Local tooling & IDE
+.agents/
+.trae/
+.claude/skills/
+skills-lock.json
+
+# Planning docs
+/plans/

--- a/apps/web/src/app/(marketing)/contact/page.tsx
+++ b/apps/web/src/app/(marketing)/contact/page.tsx
@@ -1,0 +1,151 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Contact - MeetSolis',
+  description: 'Get in touch with the MeetSolis support team.',
+};
+
+export default function ContactPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      {/* Header */}
+      <div className="bg-white border-b border-slate-200">
+        <div className="container px-4 md:px-6 pt-32 md:pt-40 pb-12 max-w-5xl mx-auto">
+          <div className="max-w-3xl">
+            <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-slate-900 mb-6 font-heading">
+              Contact Us
+            </h1>
+            <p className="text-lg text-slate-500 max-w-2xl leading-relaxed">
+              We are here to help. Reach out via email or phone and we will get
+              back to you as soon as possible.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="container px-4 md:px-6 py-16 max-w-5xl mx-auto">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {/* Email */}
+          <div className="bg-white rounded-[32px] border border-slate-200 shadow-sm p-8">
+            <div className="w-12 h-12 bg-slate-100 rounded-2xl flex items-center justify-center mb-6">
+              <svg
+                className="w-6 h-6 text-slate-700"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
+                />
+              </svg>
+            </div>
+            <h2 className="text-lg font-bold text-slate-900 mb-2">
+              Email Support
+            </h2>
+            <p className="text-sm text-slate-500 mb-4 leading-relaxed">
+              For general questions, billing inquiries, and account support. We
+              typically respond within 24 hours on business days.
+            </p>
+            <a
+              href="mailto:appmeetsolis@gmail.com"
+              className="text-sm font-semibold text-slate-900 underline hover:no-underline"
+            >
+              appmeetsolis@gmail.com
+            </a>
+          </div>
+
+          {/* Phone */}
+          <div className="bg-white rounded-[32px] border border-slate-200 shadow-sm p-8">
+            <div className="w-12 h-12 bg-slate-100 rounded-2xl flex items-center justify-center mb-6">
+              <svg
+                className="w-6 h-6 text-slate-700"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 01-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 00-1.091-.852H4.5A2.25 2.25 0 002.25 4.5v2.25z"
+                />
+              </svg>
+            </div>
+            <h2 className="text-lg font-bold text-slate-900 mb-2">
+              Phone Support
+            </h2>
+            <p className="text-sm text-slate-500 mb-4 leading-relaxed">
+              Available Monday – Friday, 10 AM – 6 PM IST. For urgent billing or
+              account issues.
+            </p>
+            <a
+              href="tel:+918591359878"
+              className="text-sm font-semibold text-slate-900 underline hover:no-underline"
+            >
+              +91 85913 59878
+            </a>
+            <p className="text-xs text-slate-400 mt-1">India (IST timezone)</p>
+          </div>
+        </div>
+
+        {/* Additional info */}
+        <div className="mt-8 bg-white rounded-[32px] border border-slate-200 shadow-sm p-8">
+          <h2 className="text-lg font-bold text-slate-900 mb-4">
+            Business Information
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-slate-600">
+            <div>
+              <p className="font-semibold text-slate-900 mb-1">Company</p>
+              <p>MeetSolis</p>
+            </div>
+            <div>
+              <p className="font-semibold text-slate-900 mb-1">Support Hours</p>
+              <p>Mon – Fri, 10 AM – 6 PM IST</p>
+            </div>
+            <div>
+              <p className="font-semibold text-slate-900 mb-1">
+                Email Response Time
+              </p>
+              <p>Within 24 business hours</p>
+            </div>
+            <div>
+              <p className="font-semibold text-slate-900 mb-1">
+                Billing Inquiries
+              </p>
+              <p>
+                <a
+                  href="mailto:appmeetsolis@gmail.com"
+                  className="underline hover:no-underline"
+                >
+                  appmeetsolis@gmail.com
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-8 text-center text-sm text-slate-500">
+          Looking for our{' '}
+          <Link
+            href="/refund"
+            className="underline hover:text-slate-900 transition-colors"
+          >
+            refund policy
+          </Link>{' '}
+          or{' '}
+          <Link
+            href="/privacy"
+            className="underline hover:text-slate-900 transition-colors"
+          >
+            privacy policy
+          </Link>
+          ?
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(marketing)/pricing/page.tsx
+++ b/apps/web/src/app/(marketing)/pricing/page.tsx
@@ -1,0 +1,237 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Pricing - MeetSolis',
+  description: 'Simple, transparent pricing for freelancers and consultants.',
+};
+
+const plans = [
+  {
+    name: 'Free',
+    price: '$0',
+    period: 'forever',
+    description: 'Get started with AI client memory at no cost.',
+    features: [
+      'Up to 3 clients',
+      '5 session transcripts (lifetime)',
+      '75 Solis queries (lifetime)',
+      'AI meeting summaries',
+      'Action item extraction',
+      'Email support',
+    ],
+    cta: 'Get Started Free',
+    href: '/sign-up',
+    highlight: false,
+  },
+  {
+    name: 'Pro',
+    price: '$99',
+    period: 'per month',
+    annualPrice: '$948',
+    annualNote: 'billed annually — save $240',
+    description:
+      'Unlimited everything. For freelancers who run on client context.',
+    features: [
+      'Unlimited clients',
+      'Unlimited session transcripts',
+      'Unlimited Solis queries',
+      'AI summaries + action items',
+      'Full client memory & context',
+      'Google Calendar integration',
+      'Priority support',
+    ],
+    cta: 'Start Pro — 30-Day Free Trial',
+    href: '/sign-up?plan=pro',
+    highlight: true,
+  },
+];
+
+const faqs = [
+  {
+    q: 'Do you offer a free trial?',
+    a: 'Yes. Pro includes a 30-day free trial — no credit card required to start.',
+  },
+  {
+    q: 'What is your refund policy?',
+    a: 'We offer a 30-day money-back guarantee on the first payment of any Pro subscription. Contact us within 30 days for a full refund.',
+  },
+  {
+    q: 'Can I cancel anytime?',
+    a: 'Yes. Cancel from your account settings at any time. You keep access until the end of your billing period.',
+  },
+  {
+    q: 'What counts as a Solis query?',
+    a: 'A Solis query is any question you ask the AI about a client — e.g. "What did we decide in last week\'s call?" Each question = one query.',
+  },
+  {
+    q: 'What payment methods do you accept?',
+    a: 'All major credit and debit cards. Payments are processed securely through our payment provider.',
+  },
+];
+
+export default function PricingPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      {/* Header */}
+      <div className="bg-white border-b border-slate-200">
+        <div className="container px-4 md:px-6 pt-32 md:pt-40 pb-12 max-w-5xl mx-auto text-center">
+          <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-slate-900 mb-6 font-heading">
+            Simple, transparent pricing
+          </h1>
+          <p className="text-lg text-slate-500 max-w-2xl mx-auto leading-relaxed">
+            Start free. Upgrade when your client list grows.
+          </p>
+        </div>
+      </div>
+
+      {/* Plans */}
+      <div className="container px-4 md:px-6 py-16 max-w-3xl mx-auto">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {plans.map(plan => (
+            <div
+              key={plan.name}
+              className={`relative flex flex-col rounded-[32px] border p-8 shadow-sm ${
+                plan.highlight
+                  ? 'bg-slate-900 border-slate-900 text-white'
+                  : 'bg-white border-slate-200'
+              }`}
+            >
+              {plan.highlight && (
+                <div className="absolute -top-3 left-1/2 -translate-x-1/2">
+                  <span className="bg-blue-600 text-white text-xs font-semibold px-4 py-1.5 rounded-full">
+                    Most Popular
+                  </span>
+                </div>
+              )}
+
+              <div className="mb-6">
+                <h2
+                  className={`text-lg font-bold mb-1 ${plan.highlight ? 'text-white' : 'text-slate-900'}`}
+                >
+                  {plan.name}
+                </h2>
+                <p
+                  className={`text-sm mb-4 ${plan.highlight ? 'text-slate-400' : 'text-slate-500'}`}
+                >
+                  {plan.description}
+                </p>
+                <div className="flex items-baseline gap-1">
+                  <span
+                    className={`text-4xl font-bold ${plan.highlight ? 'text-white' : 'text-slate-900'}`}
+                  >
+                    {plan.price}
+                  </span>
+                  <span
+                    className={`text-sm ${plan.highlight ? 'text-slate-400' : 'text-slate-500'}`}
+                  >
+                    /{plan.period}
+                  </span>
+                </div>
+                {'annualNote' in plan && (
+                  <p className="text-xs text-slate-400 mt-1">
+                    or {plan.annualPrice}/yr — {plan.annualNote}
+                  </p>
+                )}
+              </div>
+
+              <ul className="space-y-3 mb-8 flex-1">
+                {plan.features.map(feature => (
+                  <li key={feature} className="flex items-start gap-3 text-sm">
+                    <svg
+                      className={`w-4 h-4 mt-0.5 shrink-0 ${plan.highlight ? 'text-blue-400' : 'text-slate-900'}`}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2.5}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                    <span
+                      className={
+                        plan.highlight ? 'text-slate-300' : 'text-slate-600'
+                      }
+                    >
+                      {feature}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+
+              <Link
+                href={plan.href}
+                className={`w-full text-center py-3 px-6 rounded-2xl text-sm font-semibold transition-colors ${
+                  plan.highlight
+                    ? 'bg-white text-slate-900 hover:bg-slate-100'
+                    : 'bg-slate-900 text-white hover:bg-slate-800'
+                }`}
+              >
+                {plan.cta}
+              </Link>
+            </div>
+          ))}
+        </div>
+
+        {/* Money-back guarantee */}
+        <div className="mt-10 flex items-center justify-center gap-3 text-sm text-slate-500">
+          <svg
+            className="w-5 h-5 text-green-500 shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+            />
+          </svg>
+          <span>
+            30-day money-back guarantee on Pro.{' '}
+            <Link
+              href="/refund"
+              className="underline hover:text-slate-900 transition-colors"
+            >
+              See refund policy.
+            </Link>
+          </span>
+        </div>
+      </div>
+
+      {/* FAQ */}
+      <div className="container px-4 md:px-6 pb-20 max-w-3xl mx-auto">
+        <h2 className="text-2xl font-bold text-slate-900 mb-8 text-center font-heading">
+          Frequently asked questions
+        </h2>
+        <div className="space-y-4">
+          {faqs.map(faq => (
+            <div
+              key={faq.q}
+              className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm"
+            >
+              <h3 className="text-sm font-semibold text-slate-900 mb-2">
+                {faq.q}
+              </h3>
+              <p className="text-sm text-slate-600 leading-relaxed">{faq.a}</p>
+            </div>
+          ))}
+        </div>
+
+        <p className="text-center text-sm text-slate-500 mt-10">
+          More questions?{' '}
+          <Link
+            href="/contact"
+            className="text-slate-900 font-medium underline hover:no-underline"
+          >
+            Contact us
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(marketing)/privacy/page.tsx
+++ b/apps/web/src/app/(marketing)/privacy/page.tsx
@@ -53,6 +53,7 @@ export default function PrivacyPage() {
                     'Retention',
                     'Sharing',
                     'AI Processing',
+                    'Your Rights',
                   ].map(item => (
                     <div
                       key={item}
@@ -163,7 +164,44 @@ export default function PrivacyPage() {
 
               <hr className="my-8 border-slate-100" />
 
-              <h3>7. Changes to This Policy</h3>
+              <h3>7. Your Rights</h3>
+              <p>
+                Depending on your jurisdiction, you may have the following
+                rights regarding your personal data:
+              </p>
+              <ul className="marker:text-slate-400">
+                <li>
+                  <strong>Access:</strong> Request a copy of the personal data
+                  we hold about you.
+                </li>
+                <li>
+                  <strong>Correction:</strong> Request correction of inaccurate
+                  or incomplete data.
+                </li>
+                <li>
+                  <strong>Deletion:</strong> Request deletion of your personal
+                  data (&quot;right to be forgotten&quot;).
+                </li>
+                <li>
+                  <strong>Portability:</strong> Request a machine-readable
+                  export of your data.
+                </li>
+                <li>
+                  <strong>Objection:</strong> Object to processing of your data
+                  for direct marketing.
+                </li>
+              </ul>
+              <p>
+                To exercise any of these rights, email us at{' '}
+                <a href="mailto:appmeetsolis@gmail.com">
+                  appmeetsolis@gmail.com
+                </a>
+                . We will respond within 30 days.
+              </p>
+
+              <hr className="my-8 border-slate-100" />
+
+              <h3>8. Changes to This Policy</h3>
               <p>
                 We may update this Privacy Policy from time to time. We will
                 notify you of any significant changes via email or a prominent
@@ -172,7 +210,7 @@ export default function PrivacyPage() {
 
               <hr className="my-8 border-slate-100" />
 
-              <h3>8. Contact Us</h3>
+              <h3>9. Contact Us</h3>
               <p>
                 If you have any questions about this Privacy Policy or our data
                 practices, please contact us at{' '}

--- a/apps/web/src/app/(marketing)/refund/page.tsx
+++ b/apps/web/src/app/(marketing)/refund/page.tsx
@@ -1,0 +1,186 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Refund Policy - MeetSolis',
+  description: '30-day money-back guarantee. No questions asked.',
+};
+
+export default function RefundPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      {/* Header */}
+      <div className="bg-white border-b border-slate-200">
+        <div className="container px-4 md:px-6 pt-32 md:pt-40 pb-12 max-w-5xl mx-auto">
+          <div className="max-w-3xl">
+            <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-slate-900 mb-6 font-heading">
+              Refund Policy
+            </h1>
+            <p className="text-lg text-slate-500 max-w-2xl leading-relaxed">
+              We stand behind our product. If MeetSolis is not the right fit, we
+              will make it right.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="container px-4 md:px-6 py-12 max-w-5xl mx-auto">
+        <div className="flex flex-col lg:flex-row gap-12">
+          {/* Sidebar */}
+          <div className="lg:w-64 shrink-0">
+            <div className="sticky top-24 space-y-8">
+              <div className="p-6 bg-white rounded-2xl border border-slate-200 shadow-sm">
+                <div className="text-sm font-semibold text-slate-900 mb-2">
+                  Last Updated
+                </div>
+                <div className="text-slate-500">
+                  {new Date().toLocaleDateString('en-US', {
+                    month: 'long',
+                    day: 'numeric',
+                    year: 'numeric',
+                  })}
+                </div>
+              </div>
+
+              <div className="hidden lg:block">
+                <div className="text-sm font-semibold text-slate-900 mb-4 px-2">
+                  On this page
+                </div>
+                <nav className="space-y-2 text-sm text-slate-500">
+                  {[
+                    '30-Day Guarantee',
+                    'Eligibility',
+                    'How to Request',
+                    'Subscriptions',
+                    'Contact',
+                  ].map(item => (
+                    <div
+                      key={item}
+                      className="px-2 py-1 hover:text-slate-900 cursor-pointer transition-colors"
+                    >
+                      {item}
+                    </div>
+                  ))}
+                </nav>
+              </div>
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 bg-white p-8 md:p-12 rounded-[32px] border border-slate-200 shadow-sm">
+            <div className="prose prose-slate prose-lg max-w-none prose-headings:font-bold prose-headings:text-slate-900 prose-headings:scroll-mt-24 prose-p:text-slate-600 prose-p:leading-relaxed prose-li:text-slate-600 prose-a:text-blue-600 hover:prose-a:text-blue-700">
+              {/* Guarantee banner */}
+              <div className="bg-green-50 border-l-4 border-green-500 p-4 my-0 not-prose rounded-r-lg mb-8">
+                <p className="text-sm text-green-900 m-0 font-semibold">
+                  30-Day Money-Back Guarantee — No questions asked.
+                </p>
+              </div>
+
+              <h3>1. 30-Day Money-Back Guarantee</h3>
+              <p>
+                MeetSolis offers a <strong>30-day money-back guarantee</strong>{' '}
+                on all paid subscription plans (Pro and Agency). If you are
+                unsatisfied with the Service for any reason within 30 days of
+                your first payment, you are entitled to a full refund.
+              </p>
+              <p>
+                This guarantee applies to your{' '}
+                <strong>first payment only</strong> on a new subscription. It
+                does not apply to renewal payments after the initial 30-day
+                window.
+              </p>
+
+              <hr className="my-8 border-slate-100" />
+
+              <h3>2. Eligibility</h3>
+              <p>You are eligible for a refund if:</p>
+              <ul className="marker:text-slate-400">
+                <li>
+                  You are requesting a refund within 30 days of your{' '}
+                  <strong>initial</strong> subscription payment.
+                </li>
+                <li>
+                  Your account is in good standing and has not violated our{' '}
+                  <Link href="/terms">Terms of Service</Link>.
+                </li>
+                <li>
+                  You have not previously received a refund for the same plan.
+                </li>
+              </ul>
+              <p>
+                Refunds are <strong>not</strong> available for:
+              </p>
+              <ul className="marker:text-slate-400">
+                <li>Renewal charges after the initial 30-day period.</li>
+                <li>Free plan usage (the Free plan has no charges).</li>
+                <li>Partial months — we do not prorate unused time.</li>
+                <li>Accounts terminated for Terms of Service violations.</li>
+              </ul>
+
+              <hr className="my-8 border-slate-100" />
+
+              <h3>3. How to Request a Refund</h3>
+              <p>
+                To request a refund, email us at{' '}
+                <a href="mailto:appmeetsolis@gmail.com">
+                  appmeetsolis@gmail.com
+                </a>{' '}
+                with the subject line{' '}
+                <strong>&quot;Refund Request&quot;</strong> and include:
+              </p>
+              <ul className="marker:text-slate-400">
+                <li>Your account email address.</li>
+                <li>The date of your payment.</li>
+                <li>
+                  The reason for your refund request (optional, but it helps us
+                  improve).
+                </li>
+              </ul>
+              <p>
+                We will process your refund within{' '}
+                <strong>5–10 business days</strong>. Refunds are returned to the
+                original payment method.
+              </p>
+
+              <hr className="my-8 border-slate-100" />
+
+              <h3>4. Subscriptions and Cancellations</h3>
+              <p>
+                You may cancel your subscription at any time from your account
+                settings. Cancellation stops future billing. You retain access
+                to paid features until the end of your current billing period.
+              </p>
+              <p>
+                Cancelling a subscription does <strong>not</strong>{' '}
+                automatically trigger a refund. To request a refund, follow the
+                process in Section 3 above.
+              </p>
+
+              <hr className="my-8 border-slate-100" />
+
+              <h3>5. Payment Processor</h3>
+              <p>
+                Payments for MeetSolis subscriptions are processed by our
+                authorized payment partners. When you purchase a subscription,
+                you are buying from MeetSolis directly. Your billing statement
+                may show the name of our payment processor.
+              </p>
+
+              <hr className="my-8 border-slate-100" />
+
+              <h3>6. Contact Us</h3>
+              <p>
+                If you have questions about this Refund Policy, please{' '}
+                <Link href="/contact">contact us</Link> or email{' '}
+                <a href="mailto:appmeetsolis@gmail.com">
+                  appmeetsolis@gmail.com
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(marketing)/terms/page.tsx
+++ b/apps/web/src/app/(marketing)/terms/page.tsx
@@ -53,6 +53,7 @@ export default function TermsPage() {
                     'Privacy',
                     'Intellectual Property',
                     'Acceptable Use',
+                    'Payments & Refunds',
                   ].map(item => (
                     <div
                       key={item}
@@ -162,7 +163,33 @@ export default function TermsPage() {
 
               <hr className="my-8 border-slate-100" />
 
-              <h3>8. Modifications to Service</h3>
+              <h3>8. Payments, Subscriptions, and Refunds</h3>
+              <p>
+                MeetSolis offers free and paid subscription plans. By
+                subscribing to a paid plan, you authorize us to charge your
+                payment method on a recurring basis.
+              </p>
+              <p>
+                <strong>Payment Processing:</strong> Payments are processed by
+                our authorized payment partners acting as the reseller of
+                MeetSolis subscriptions. Your billing statement may reflect the
+                name of our payment processor.
+              </p>
+              <p>
+                <strong>Refunds:</strong> We offer a 30-day money-back guarantee
+                on the first payment of any new paid subscription. See our{' '}
+                <a href="/refund">Refund Policy</a> for full details.
+              </p>
+              <p>
+                <strong>Cancellation:</strong> You may cancel your subscription
+                at any time from your account settings. Cancellation stops
+                future billing. Access continues until the end of the current
+                billing period.
+              </p>
+
+              <hr className="my-8 border-slate-100" />
+
+              <h3>9. Modifications to Service</h3>
               <p>
                 We reserve the right to modify or discontinue, temporarily or
                 permanently, the Service (or any part thereof) with or without
@@ -171,7 +198,7 @@ export default function TermsPage() {
 
               <hr className="my-8 border-slate-100" />
 
-              <h3>9. Governing Law</h3>
+              <h3>10. Governing Law</h3>
               <p>
                 These Terms shall be governed and construed in accordance with
                 the laws of India, without regard to its conflict of law
@@ -180,7 +207,7 @@ export default function TermsPage() {
 
               <hr className="my-8 border-slate-100" />
 
-              <h3>10. Contact Us</h3>
+              <h3>11. Contact Us</h3>
               <p>
                 If you have any questions about these Terms, please contact us
                 at{' '}

--- a/apps/web/src/components/marketing/layout/Footer.tsx
+++ b/apps/web/src/components/marketing/layout/Footer.tsx
@@ -7,58 +7,154 @@ export function Footer() {
     <footer className="py-20 bg-[#0B0F19] text-slate-400 border-t border-white/5">
       <div className="container px-4 md:px-6">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-12 md:gap-8 mb-16">
-
           {/* Brand Column */}
           <div className="space-y-6">
             <Link href="/" className="flex items-center gap-2">
               <div className="w-14 h-14 overflow-hidden flex items-center justify-center">
-                <img src="/logo.jpg" alt="Solis" className="w-full h-full object-contain rounded-xl" />
+                <img
+                  src="/logo.jpg"
+                  alt="Solis"
+                  className="w-full h-full object-contain rounded-xl"
+                />
               </div>
-              <span className="text-2xl font-bold text-white tracking-tight">MeetSolis</span>
+              <span className="text-2xl font-bold text-white tracking-tight">
+                MeetSolis
+              </span>
             </Link>
             <p className="text-sm leading-relaxed max-w-xs">
-              The AI memory layer for client-facing freelancers. Never miss a detail again.
+              The AI memory layer for client-facing freelancers. Never miss a
+              detail again.
             </p>
           </div>
 
           {/* Column 1: Product */}
           <div className="space-y-6">
-            <h4 className="text-sm font-bold text-white uppercase tracking-wider">Product</h4>
+            <h4 className="text-sm font-bold text-white uppercase tracking-wider">
+              Product
+            </h4>
             <ul className="space-y-4 text-sm">
-              <li><Link href="#features" className="hover:text-white transition-colors">Features</Link></li>
-              <li><Link href="#how-it-works" className="hover:text-white transition-colors">How it Works</Link></li>
-              <li><Link href="/pricing" className="hover:text-white transition-colors">Pricing</Link></li>
-              <li><Link href="#faq" className="hover:text-white transition-colors">FAQ</Link></li>
+              <li>
+                <Link
+                  href="#features"
+                  className="hover:text-white transition-colors"
+                >
+                  Features
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="#how-it-works"
+                  className="hover:text-white transition-colors"
+                >
+                  How it Works
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/pricing"
+                  className="hover:text-white transition-colors"
+                >
+                  Pricing
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="#faq"
+                  className="hover:text-white transition-colors"
+                >
+                  FAQ
+                </Link>
+              </li>
             </ul>
           </div>
 
           {/* Column 2: Resources */}
           <div className="space-y-6">
-            <h4 className="text-sm font-bold text-white uppercase tracking-wider">Resources</h4>
+            <h4 className="text-sm font-bold text-white uppercase tracking-wider">
+              Resources
+            </h4>
             <ul className="space-y-4 text-sm">
-              <li><Link href="#faq" className="hover:text-white transition-colors">Help Center</Link></li>
-              <li><a href="mailto:appmeetsolis@gmail.com" className="hover:text-white transition-colors">Contact Support</a></li>
+              <li>
+                <Link
+                  href="#faq"
+                  className="hover:text-white transition-colors"
+                >
+                  Help Center
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/contact"
+                  className="hover:text-white transition-colors"
+                >
+                  Contact Support
+                </Link>
+              </li>
             </ul>
           </div>
 
           {/* Column 3: Legal */}
           <div className="space-y-6">
-            <h4 className="text-sm font-bold text-white uppercase tracking-wider">Legal</h4>
+            <h4 className="text-sm font-bold text-white uppercase tracking-wider">
+              Legal
+            </h4>
             <ul className="space-y-4 text-sm">
-              <li><Link href="/privacy" className="hover:text-white transition-colors">Privacy Policy</Link></li>
-              <li><Link href="/terms" className="hover:text-white transition-colors">Terms of Service</Link></li>
+              <li>
+                <Link
+                  href="/privacy"
+                  className="hover:text-white transition-colors"
+                >
+                  Privacy Policy
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/terms"
+                  className="hover:text-white transition-colors"
+                >
+                  Terms of Service
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/refund"
+                  className="hover:text-white transition-colors"
+                >
+                  Refund Policy
+                </Link>
+              </li>
             </ul>
           </div>
-
         </div>
 
         {/* Bottom Bar */}
         <div className="pt-8 border-t border-white/5 flex flex-col md:flex-row items-center justify-between gap-4 text-xs">
-          <p>© {new Date().getFullYear()} Solis Inc. All rights reserved.</p>
+          <p>© {new Date().getFullYear()} MeetSolis. All rights reserved.</p>
           <div className="flex items-center gap-6">
-            <Link href="https://x.com/SutharHarigopal" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">Twitter</Link>
-            <Link href="https://www.linkedin.com/in/harigopal-suthar-6a3372307/" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">LinkedIn</Link>
-            <Link href="https://www.instagram.com/harigopalsuthar/" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">Instagram</Link>
+            <Link
+              href="https://x.com/SutharHarigopal"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-white transition-colors"
+            >
+              Twitter
+            </Link>
+            <Link
+              href="https://www.linkedin.com/in/harigopal-suthar-6a3372307/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-white transition-colors"
+            >
+              LinkedIn
+            </Link>
+            <Link
+              href="https://www.instagram.com/harigopalsuthar/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-white transition-colors"
+            >
+              Instagram
+            </Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add pricing, contact, refund pages for payment processor approval (Paddle/Dodo/LemonSqueezy)
- Update privacy policy (Your Rights section) and terms (Payments & Refunds section)
- Footer: refund link, contact page link, copyright fix
- Fix `.gitignore` — scope `marketing/` to root-only, add local-only dirs

## Test plan
- [ ] `/pricing`, `/contact`, `/refund` pages load
- [ ] Privacy/Terms updated sections render correctly
- [ ] Footer links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)