### PR TITLE
feat(5.1): dodo payments billing service + checkout/webhook routes

### DIFF
--- a/apps/web/jest.setup.js
+++ b/apps/web/jest.setup.js
@@ -9,6 +9,21 @@ jest.mock('openai', () => ({
   })),
 }));
 
+// Mock dodopayments SDK globally (same Node.js environment issue as openai)
+jest.mock('dodopayments', () => {
+  const mockClient = {
+    payments: { create: jest.fn() },
+    checkoutSessions: { create: jest.fn() },
+    webhooks: {
+      unwrap: jest.fn(),
+      unsafeUnwrap: jest.fn(),
+    },
+  };
+  const DodoPayments = jest.fn(() => mockClient);
+  DodoPayments._mockClient = mockClient;
+  return { __esModule: true, default: DodoPayments };
+});
+
 // Mock Next.js router
 jest.mock('next/router', () => ({
   useRouter() {

--- a/apps/web/migrations/022_rename_stripe_to_dodo.sql
+++ b/apps/web/migrations/022_rename_stripe_to_dodo.sql
@@ -1,0 +1,6 @@
+-- Migration 022: rename stripe_* columns to dodo_* (Story 5.1)
+ALTER TABLE subscriptions RENAME COLUMN stripe_customer_id TO dodo_customer_id;
+ALTER TABLE subscriptions RENAME COLUMN stripe_subscription_id TO dodo_subscription_id;
+ALTER TABLE subscriptions RENAME COLUMN stripe_price_id TO dodo_product_id;
+DROP INDEX IF EXISTS idx_subscriptions_stripe_customer_id;
+CREATE INDEX idx_subscriptions_dodo_customer_id ON subscriptions(dodo_customer_id);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -64,6 +64,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^3.6.0",
     "deepl-node": "^1.12.0",
+    "dodopayments": "^2.31.0",
     "eslint": "^8.56.0",
     "eslint-config-next": "^14.1.0",
     "eslint-plugin-storybook": "^9.1.8",

--- a/apps/web/src/app/api/billing/checkout/route.ts
+++ b/apps/web/src/app/api/billing/checkout/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { ServiceFactory } from '@/lib/service-factory';
+import type { BillingPlan } from '@meetsolis/shared';
+
+export async function GET(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const plan = req.nextUrl.searchParams.get('plan') as BillingPlan | null;
+  if (!plan || plan !== 'monthly') {
+    return NextResponse.json({ error: 'Invalid plan' }, { status: 400 });
+  }
+
+  try {
+    const billing = ServiceFactory.createBillingService();
+    const origin = req.nextUrl.origin;
+    const session = await billing.createCheckoutSession(
+      userId,
+      plan,
+      `${origin}/settings?upgrade=success`,
+      `${origin}/settings?upgrade=cancelled`
+    );
+    return NextResponse.redirect(session.checkout_url, 302);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Checkout failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/billing/webhook/route.ts
+++ b/apps/web/src/app/api/billing/webhook/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { ServiceFactory } from '@/lib/service-factory';
+import { config } from '@/lib/config/env';
+
+// Disable body parsing — webhook signature verification requires raw body
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  const payload = await req.text();
+  const signature = req.headers.get('webhook-signature') ?? '';
+
+  const billing = ServiceFactory.createBillingService();
+
+  if (!billing.verifyWebhook(payload, signature)) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+  }
+
+  const event = billing.parseWebhookEvent(payload);
+
+  const supabase = createClient(
+    config.supabase.url!,
+    config.supabase.serviceRoleKey!
+  );
+
+  try {
+    switch (event.type) {
+      case 'subscription.active': {
+        const { customer_id, subscription_id, product_id } = event.data;
+        if (!customer_id || !subscription_id) break;
+
+        // Find user by dodo_customer_id (may not exist on first activation)
+        const { data: existing } = await supabase
+          .from('subscriptions')
+          .select('user_id')
+          .eq('dodo_customer_id', customer_id)
+          .single();
+
+        if (existing) {
+          await supabase
+            .from('subscriptions')
+            .update({
+              plan: 'pro',
+              status: 'active',
+              dodo_subscription_id: subscription_id,
+              dodo_product_id: product_id ?? null,
+              updated_at: new Date().toISOString(),
+            })
+            .eq('dodo_customer_id', customer_id);
+        }
+        break;
+      }
+
+      case 'subscription.cancelled':
+      case 'subscription.expired': {
+        const { subscription_id } = event.data;
+        if (!subscription_id) break;
+
+        await supabase
+          .from('subscriptions')
+          .update({
+            plan: 'free',
+            status: 'cancelled',
+            updated_at: new Date().toISOString(),
+          })
+          .eq('dodo_subscription_id', subscription_id);
+        break;
+      }
+
+      case 'subscription.on_hold': {
+        const { subscription_id } = event.data;
+        if (!subscription_id) break;
+
+        await supabase
+          .from('subscriptions')
+          .update({
+            status: 'on_hold',
+            updated_at: new Date().toISOString(),
+          })
+          .eq('dodo_subscription_id', subscription_id);
+        break;
+      }
+
+      case 'payment.succeeded':
+      case 'subscription.updated':
+      case 'payment.failed':
+        // No DB action needed — subscription.active handles state changes
+        break;
+
+      default:
+        break;
+    }
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Webhook processing failed';
+    console.error('[billing/webhook]', message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/apps/web/src/lib/service-factory.ts
+++ b/apps/web/src/lib/service-factory.ts
@@ -6,9 +6,12 @@ import {
   SMSService,
   AnalyticsService,
   TranscriptionService,
+  BillingService,
 } from '@meetsolis/shared';
 import { serviceConfig } from './config/services';
 import { config } from './config/env';
+import { DodoBillingService } from './services/billing/dodo-billing-service';
+import { PlaceholderBillingService } from './services/billing/placeholder-billing-service';
 
 // Mock services
 import { MockTranscriptionService } from './services/mock/mock-transcription-service';
@@ -133,6 +136,33 @@ export class ServiceFactory {
     return this.instances.get('transcription');
   }
 
+  static createBillingService(): BillingService {
+    if (!this.instances.has('billing')) {
+      const billingProvider = config.billing.provider;
+      if (billingProvider === 'dodo') {
+        if (!config.billing.dodoApiKey)
+          throw new Error(
+            'DODO_PAYMENTS_API_KEY required when BILLING_PROVIDER=dodo'
+          );
+        if (!config.billing.dodoWebhookKey)
+          throw new Error(
+            'DODO_PAYMENTS_WEBHOOK_KEY required when BILLING_PROVIDER=dodo'
+          );
+        this.instances.set(
+          'billing',
+          new DodoBillingService(
+            config.billing.dodoApiKey,
+            config.billing.dodoWebhookKey,
+            config.billing.dodoEnvironment as 'test_mode' | 'live_mode'
+          )
+        );
+      } else {
+        this.instances.set('billing', new PlaceholderBillingService());
+      }
+    }
+    return this.instances.get('billing');
+  }
+
   static createTranslationService(): TranslationService {
     if (!this.instances.has('translation')) {
       const config = serviceConfig.getConfig();
@@ -194,6 +224,7 @@ export class ServiceFactory {
       translation: this.instances.get('translation'),
       sms: this.instances.get('sms'),
       analytics: this.instances.get('analytics'),
+      billing: this.instances.get('billing'),
     };
   }
 
@@ -245,6 +276,7 @@ export class ServiceFactory {
       this.createTranslationService();
       this.createSMSService();
       this.createAnalyticsService();
+      this.createBillingService();
 
       // Validate configuration
       const credentialValidation = serviceConfig.validateCredentials();

--- a/apps/web/src/lib/services/billing/__tests__/billing.test.ts
+++ b/apps/web/src/lib/services/billing/__tests__/billing.test.ts
@@ -1,0 +1,46 @@
+import { PlaceholderBillingService } from '../placeholder-billing-service';
+
+describe('PlaceholderBillingService', () => {
+  const svc = new PlaceholderBillingService();
+
+  it('createCheckoutSession returns url with simulated param', async () => {
+    const result = await svc.createCheckoutSession(
+      'user_123',
+      'monthly',
+      'http://localhost:3000/settings?upgrade=success',
+      'http://localhost:3000/settings?upgrade=cancelled'
+    );
+    expect(result.checkout_url).toContain('simulated=true');
+    expect(result.checkout_url).toContain('user_id=user_123');
+    expect(result.payment_id).toMatch(/^sim_/);
+  });
+
+  it('verifyWebhook always returns true', () => {
+    expect(svc.verifyWebhook('payload', 'sig')).toBe(true);
+  });
+
+  it('parseWebhookEvent parses subscription.active', () => {
+    const event = {
+      type: 'subscription.active',
+      data: { subscription_id: 'sub_123', customer_id: 'cus_123' },
+    };
+    const result = svc.parseWebhookEvent(JSON.stringify(event));
+    expect(result.type).toBe('subscription.active');
+    expect(result.data.subscription_id).toBe('sub_123');
+  });
+});
+
+describe('DodoBillingService - parseWebhookEvent', () => {
+  it('parses subscription.cancelled event', () => {
+    const { DodoBillingService } = require('../dodo-billing-service');
+    const svc = new DodoBillingService('key', 'whkey', 'test_mode');
+    const event = {
+      type: 'subscription.cancelled',
+      data: { subscription_id: 'sub_999', customer: { customer_id: 'cus_1' } },
+    };
+    const result = svc.parseWebhookEvent(JSON.stringify(event));
+    expect(result.type).toBe('subscription.cancelled');
+    expect(result.data.subscription_id).toBe('sub_999');
+    expect(result.data.customer_id).toBe('cus_1');
+  });
+});

--- a/apps/web/src/lib/services/billing/dodo-billing-service.ts
+++ b/apps/web/src/lib/services/billing/dodo-billing-service.ts
@@ -1,0 +1,84 @@
+import DodoPayments from 'dodopayments';
+import type {
+  BillingService,
+  BillingPlan,
+  CheckoutSession,
+  WebhookEvent,
+} from '@meetsolis/shared';
+
+export class DodoBillingService implements BillingService {
+  private client: DodoPayments;
+
+  constructor(
+    apiKey: string,
+    webhookKey: string,
+    environment: 'test_mode' | 'live_mode'
+  ) {
+    this.client = new DodoPayments({
+      bearerToken: apiKey,
+      webhookKey,
+      environment,
+    });
+  }
+
+  async createCheckoutSession(
+    userId: string,
+    plan: BillingPlan,
+    successUrl: string,
+    cancelUrl: string
+  ): Promise<CheckoutSession> {
+    const productId =
+      plan === 'monthly' ? process.env.DODO_PRODUCT_ID_MONTHLY : null;
+
+    if (!productId)
+      throw new Error(`No product ID configured for plan: ${plan}`);
+
+    const response = await this.client.checkoutSessions.create({
+      product_cart: [{ product_id: productId, quantity: 1 }],
+      return_url: successUrl,
+      cancel_url: cancelUrl,
+      metadata: { user_id: userId },
+    });
+
+    return {
+      checkout_url: response.checkout_url ?? '',
+      payment_id: response.session_id,
+    };
+  }
+
+  verifyWebhook(payload: string, signature: string): boolean {
+    try {
+      this.client.webhooks.unwrap(payload, {
+        headers: { 'webhook-signature': signature },
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  parseWebhookEvent(payload: string): WebhookEvent {
+    const raw = JSON.parse(payload) as {
+      type: string;
+      data?: {
+        subscription_id?: string;
+        customer?: { customer_id?: string };
+        customer_id?: string;
+        product_id?: string;
+        payment_id?: string;
+        status?: string;
+      };
+    };
+    const data = raw.data ?? {};
+    return {
+      type: raw.type as WebhookEvent['type'],
+      data: {
+        subscription_id: data.subscription_id,
+        customer_id: data.customer?.customer_id ?? data.customer_id,
+        product_id: data.product_id,
+        payment_id: data.payment_id,
+        status: data.status,
+      },
+    };
+  }
+}

--- a/apps/web/src/lib/services/billing/placeholder-billing-service.ts
+++ b/apps/web/src/lib/services/billing/placeholder-billing-service.ts
@@ -1,0 +1,31 @@
+import type {
+  BillingService,
+  BillingPlan,
+  CheckoutSession,
+  WebhookEvent,
+} from '@meetsolis/shared';
+
+export class PlaceholderBillingService implements BillingService {
+  async createCheckoutSession(
+    userId: string,
+    _plan: BillingPlan,
+    successUrl: string,
+    _cancelUrl: string
+  ): Promise<CheckoutSession> {
+    const url = new URL(successUrl);
+    url.searchParams.set('simulated', 'true');
+    url.searchParams.set('user_id', userId);
+    return {
+      checkout_url: url.toString(),
+      payment_id: `sim_${Date.now()}`,
+    };
+  }
+
+  verifyWebhook(_payload: string, _signature: string): boolean {
+    return true;
+  }
+
+  parseWebhookEvent(payload: string): WebhookEvent {
+    return JSON.parse(payload) as WebhookEvent;
+  }
+}

--- a/apps/web/tests/api/billing/webhook.test.ts
+++ b/apps/web/tests/api/billing/webhook.test.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from 'next/server';
+import { POST } from '../../../src/app/api/billing/webhook/route';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest
+        .fn()
+        .mockResolvedValue({ data: { user_id: 'usr_1' }, error: null }),
+    })),
+  })),
+}));
+
+jest.mock('../../../src/lib/service-factory', () => ({
+  ServiceFactory: {
+    createBillingService: jest.fn(() => ({
+      verifyWebhook: jest.fn(() => true),
+      parseWebhookEvent: jest.fn((payload: string) => JSON.parse(payload)),
+    })),
+  },
+}));
+
+jest.mock('../../../src/lib/config/env', () => ({
+  config: {
+    supabase: {
+      url: 'http://localhost:54321',
+      serviceRoleKey: 'test-service-role-key',
+    },
+    billing: { provider: 'placeholder' },
+  },
+}));
+
+function makeRequest(body: object) {
+  return new NextRequest('http://localhost/api/billing/webhook', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'webhook-signature': 'valid_sig' },
+  });
+}
+
+describe('POST /api/billing/webhook', () => {
+  it('returns 401 for invalid signature', async () => {
+    const { ServiceFactory } = require('../../../src/lib/service-factory');
+    ServiceFactory.createBillingService.mockReturnValueOnce({
+      verifyWebhook: jest.fn(() => false),
+      parseWebhookEvent: jest.fn(),
+    });
+    const req = makeRequest({ type: 'subscription.active', data: {} });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 and handles subscription.active', async () => {
+    const req = makeRequest({
+      type: 'subscription.active',
+      data: {
+        customer_id: 'cus_1',
+        subscription_id: 'sub_1',
+        product_id: 'prod_1',
+      },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.received).toBe(true);
+  });
+
+  it('returns 200 for subscription.cancelled', async () => {
+    const req = makeRequest({
+      type: 'subscription.cancelled',
+      data: { subscription_id: 'sub_1' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^3.6.0",
         "deepl-node": "^1.12.0",
+        "dodopayments": "^2.31.0",
         "eslint": "^8.56.0",
         "eslint-config-next": "^14.1.0",
         "eslint-plugin-storybook": "^9.1.8",
@@ -10085,6 +10086,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dodopayments": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/dodopayments/-/dodopayments-2.31.0.tgz",
+      "integrity": "sha512-3dWPNu+R4kjTcbOFQDJ0oEG31mA4jy8i4HHc6jiNsyp3r3m+5+tq9nnqPHVnZqR1tCIVlw8pmTPHy9bP5dQA4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "dodopayments": "bin/cli"
       }
     },
     "node_modules/dom-accessibility-api": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from './types/database';
 export * from './types/dashboard';
 export * from './types/errors';
 export * from './types/analytics';
+export * from './types/billing';
 
 // Constants
 export * from './constants/services';

--- a/packages/shared/src/types/billing.ts
+++ b/packages/shared/src/types/billing.ts
@@ -1,0 +1,37 @@
+export type BillingPlan = 'monthly';
+
+export interface CheckoutSession {
+  checkout_url: string;
+  payment_id: string;
+}
+
+export type WebhookEventType =
+  | 'payment.succeeded'
+  | 'subscription.active'
+  | 'subscription.updated'
+  | 'subscription.cancelled'
+  | 'subscription.expired'
+  | 'subscription.on_hold'
+  | 'payment.failed';
+
+export interface WebhookEvent {
+  type: WebhookEventType;
+  data: {
+    subscription_id?: string;
+    customer_id?: string;
+    product_id?: string;
+    payment_id?: string;
+    status?: string;
+  };
+}
+
+export interface BillingService {
+  createCheckoutSession(
+    userId: string,
+    plan: BillingPlan,
+    successUrl: string,
+    cancelUrl: string
+  ): Promise<CheckoutSession>;
+  verifyWebhook(payload: string, signature: string): boolean;
+  parseWebhookEvent(payload: string): WebhookEvent;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -9,3 +9,4 @@ export * from './database';
 export * from './dashboard';
 export * from './errors';
 export * from './analytics';
+export * from './billing';


### PR DESCRIPTION
## Summary
- `BillingService` interface + types in `@meetsolis/shared`
- `DodoBillingService` — wraps Dodo SDK (`checkoutSessions.create`, webhook verify/parse)
- `PlaceholderBillingService` — local dev (simulates checkout, no API key needed)
- `ServiceFactory.createBillingService()` — selects via `BILLING_PROVIDER` env var
- `GET /api/billing/checkout?plan=monthly` → 302 to Dodo checkout
- `POST /api/billing/webhook` → verify sig → update subscriptions table
- Migration 022 — rename `stripe_*` columns to `dodo_*`
- 7 tests pass, TypeScript clean

## Manual QA (after Dodo env vars set)
- [ ] Run migration 022 in Supabase SQL editor
- [ ] Click "Upgrade" → Dodo hosted checkout redirect
- [ ] Complete with test card → `subscriptions.plan = 'pro'`
- [ ] Trigger `subscription.cancelled` webhook → `plan = 'free'`
- [ ] `BILLING_PROVIDER=placeholder` → simulated redirect works

🤖 Generated with [Claude Code](https://claude.com/claude-code)