### PR TITLE
feat(5.2): tier enforcement — admin bypass + increment error hardening

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -63,6 +63,10 @@ NEXT_PUBLIC_APP_VERSION=1.0.0
 # Alerting - Slack
 SLACK_WEBHOOK_URL=
 
+# Dev/testing overrides
+# Set to true to bypass tier limits locally (disabled automatically in production)
+ADMIN_BYPASS_LIMITS=false
+
 # Service Configuration
 USE_MOCK_SERVICES=true
 NEXT_PUBLIC_USE_MOCK_SERVICES=true

--- a/apps/web/src/lib/billing/__tests__/checkUsage.test.ts
+++ b/apps/web/src/lib/billing/__tests__/checkUsage.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for checkUsage.ts — Story 4.4
+ * Unit tests for checkUsage.ts — Stories 4.4 + 5.2
  */
 
 import {
@@ -11,12 +11,14 @@ import {
   LIMITS,
 } from '../checkUsage';
 import { UpgradeRequiredError } from '@meetsolis/shared';
+import * as Sentry from '@sentry/nextjs';
+import { config } from '@/lib/config/env';
+
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
+jest.mock('@/lib/config/env', () => ({ config: { adminBypassLimits: false } }));
 
 // Mock Supabase server client
-const mockSupabase = {
-  from: jest.fn(),
-};
-
+const mockSupabase = { from: jest.fn() };
 jest.mock('@/lib/supabase/server', () => ({
   getSupabaseServerClient: jest.fn(() => mockSupabase),
 }));
@@ -66,6 +68,43 @@ describe('LIMITS', () => {
     expect(LIMITS.pro.clients).toBe(Infinity);
     expect(LIMITS.pro.transcripts).toBe(25);
     expect(LIMITS.pro.queries).toBe(2000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Admin bypass
+// ---------------------------------------------------------------------------
+
+describe('admin bypass', () => {
+  afterEach(() => {
+    (config as any).adminBypassLimits = false;
+    jest.clearAllMocks();
+  });
+
+  it('bypasses all limit checks when adminBypassLimits=true', async () => {
+    (config as any).adminBypassLimits = true;
+
+    await expect(checkClientLimit('admin-user')).resolves.toBeUndefined();
+    await expect(checkTranscriptLimit('admin-user')).resolves.toBeUndefined();
+    await expect(checkQueryLimit('admin-user')).resolves.toBeUndefined();
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+
+  it('enforces limits normally when adminBypassLimits=false (production default)', async () => {
+    // config.adminBypassLimits is false by default — mirrors production
+    setupSupabase({
+      subscriptions: {
+        ...makeChain(),
+        maybeSingle: jest.fn().mockResolvedValue({ data: null }),
+      },
+      clients: {
+        ...makeChain(),
+        eq: jest.fn().mockResolvedValue({ count: 0, error: null }),
+      },
+    });
+
+    await expect(checkClientLimit('user-1')).resolves.toBeUndefined();
+    expect(mockSupabase.from).toHaveBeenCalled();
   });
 });
 
@@ -153,12 +192,10 @@ describe('checkTranscriptLimit', () => {
         ...makeChain(),
         upsert: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
-        single: jest
-          .fn()
-          .mockResolvedValue({
-            data: { ...baseUsage, transcript_count: 4 },
-            error: null,
-          }),
+        single: jest.fn().mockResolvedValue({
+          data: { ...baseUsage, transcript_count: 4 },
+          error: null,
+        }),
       },
     });
 
@@ -175,12 +212,10 @@ describe('checkTranscriptLimit', () => {
         ...makeChain(),
         upsert: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
-        single: jest
-          .fn()
-          .mockResolvedValue({
-            data: { ...baseUsage, transcript_count: 5 },
-            error: null,
-          }),
+        single: jest.fn().mockResolvedValue({
+          data: { ...baseUsage, transcript_count: 5 },
+          error: null,
+        }),
       },
     });
 
@@ -203,16 +238,14 @@ describe('checkTranscriptLimit', () => {
         ...makeChain(),
         upsert: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
-        single: jest
-          .fn()
-          .mockResolvedValue({
-            data: {
-              ...baseUsage,
-              transcript_count: 10,
-              transcript_reset_at: recentReset,
-            },
-            error: null,
-          }),
+        single: jest.fn().mockResolvedValue({
+          data: {
+            ...baseUsage,
+            transcript_count: 10,
+            transcript_reset_at: recentReset,
+          },
+          error: null,
+        }),
       },
     });
 
@@ -248,16 +281,14 @@ describe('checkTranscriptLimit', () => {
         return {
           upsert: jest.fn().mockReturnThis(),
           select: jest.fn().mockReturnThis(),
-          single: jest
-            .fn()
-            .mockResolvedValue({
-              data: {
-                ...baseUsage,
-                transcript_count: 10,
-                transcript_reset_at: oldReset,
-              },
-              error: null,
-            }),
+          single: jest.fn().mockResolvedValue({
+            data: {
+              ...baseUsage,
+              transcript_count: 10,
+              transcript_reset_at: oldReset,
+            },
+            error: null,
+          }),
           update: updateMock,
           eq: jest.fn().mockReturnThis(),
         };
@@ -287,12 +318,10 @@ describe('checkQueryLimit', () => {
         ...makeChain(),
         upsert: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
-        single: jest
-          .fn()
-          .mockResolvedValue({
-            data: { ...baseUsage, query_count: 75 },
-            error: null,
-          }),
+        single: jest.fn().mockResolvedValue({
+          data: { ...baseUsage, query_count: 75 },
+          error: null,
+        }),
       },
     });
 
@@ -312,16 +341,14 @@ describe('checkQueryLimit', () => {
         ...makeChain(),
         upsert: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
-        single: jest
-          .fn()
-          .mockResolvedValue({
-            data: {
-              ...baseUsage,
-              query_count: 2000,
-              query_reset_at: recentReset,
-            },
-            error: null,
-          }),
+        single: jest.fn().mockResolvedValue({
+          data: {
+            ...baseUsage,
+            query_count: 2000,
+            query_reset_at: recentReset,
+          },
+          error: null,
+        }),
       },
     });
 
@@ -347,12 +374,10 @@ describe('incrementTranscriptCount', () => {
         return {
           upsert: jest.fn().mockReturnThis(),
           select: jest.fn().mockReturnThis(),
-          single: jest
-            .fn()
-            .mockResolvedValue({
-              data: { ...baseUsage, transcript_count: 3 },
-              error: null,
-            }),
+          single: jest.fn().mockResolvedValue({
+            data: { ...baseUsage, transcript_count: 3 },
+            error: null,
+          }),
           update: updateMock,
           eq: jest.fn().mockReturnThis(),
         };
@@ -378,12 +403,10 @@ describe('incrementTranscriptCount', () => {
         return {
           upsert: jest.fn().mockReturnThis(),
           select: jest.fn().mockReturnThis(),
-          single: jest
-            .fn()
-            .mockResolvedValue({
-              data: { ...baseUsage, transcript_count: 2 },
-              error: null,
-            }),
+          single: jest.fn().mockResolvedValue({
+            data: { ...baseUsage, transcript_count: 2 },
+            error: null,
+          }),
           update: updateMock,
           eq: jest.fn().mockReturnThis(),
         };
@@ -393,6 +416,12 @@ describe('incrementTranscriptCount', () => {
 
     await expect(incrementTranscriptCount('user-1')).rejects.toThrow(
       'Failed to increment transcript count'
+    );
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        extra: { userId: 'user-1', type: 'increment_transcript' },
+      })
     );
   });
 });
@@ -409,12 +438,10 @@ describe('incrementQueryCount', () => {
         return {
           upsert: jest.fn().mockReturnThis(),
           select: jest.fn().mockReturnThis(),
-          single: jest
-            .fn()
-            .mockResolvedValue({
-              data: { ...baseUsage, query_count: 10 },
-              error: null,
-            }),
+          single: jest.fn().mockResolvedValue({
+            data: { ...baseUsage, query_count: 10 },
+            error: null,
+          }),
           update: updateMock,
           eq: jest.fn().mockReturnThis(),
         };
@@ -440,12 +467,10 @@ describe('incrementQueryCount', () => {
         return {
           upsert: jest.fn().mockReturnThis(),
           select: jest.fn().mockReturnThis(),
-          single: jest
-            .fn()
-            .mockResolvedValue({
-              data: { ...baseUsage, query_count: 5 },
-              error: null,
-            }),
+          single: jest.fn().mockResolvedValue({
+            data: { ...baseUsage, query_count: 5 },
+            error: null,
+          }),
           update: updateMock,
           eq: jest.fn().mockReturnThis(),
         };
@@ -455,6 +480,12 @@ describe('incrementQueryCount', () => {
 
     await expect(incrementQueryCount('user-1')).rejects.toThrow(
       'Failed to increment query count'
+    );
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        extra: { userId: 'user-1', type: 'increment_query' },
+      })
     );
   });
 });

--- a/apps/web/src/lib/billing/checkUsage.ts
+++ b/apps/web/src/lib/billing/checkUsage.ts
@@ -1,14 +1,26 @@
 /**
- * Usage enforcement — Story 4.4
+ * Usage enforcement — Stories 4.4 + 5.2
  * Server-side limit checks for free/pro tiers.
  */
 
+import * as Sentry from '@sentry/nextjs';
 import { getSupabaseServerClient } from '@/lib/supabase/server';
+import { config } from '@/lib/config/env';
 import {
   UpgradeRequiredError,
   type UsageTracking,
   type SubscriptionPlan,
 } from '@meetsolis/shared';
+
+// ---------------------------------------------------------------------------
+// Admin bypass (dev/test only — disabled in production)
+// ---------------------------------------------------------------------------
+
+function isAdminBypassActive(userId: string): boolean {
+  if (!config.adminBypassLimits) return false;
+  console.log(`[admin] limit check bypassed for ${userId}`);
+  return true;
+}
 
 // ---------------------------------------------------------------------------
 // Limits
@@ -107,6 +119,7 @@ async function maybeResetMonthlyCounter(
 // ---------------------------------------------------------------------------
 
 export async function checkClientLimit(userId: string): Promise<void> {
+  if (isAdminBypassActive(userId)) return;
   const supabase = getSupabaseServerClient();
   const tier = await getUserTier(userId, supabase);
 
@@ -125,6 +138,7 @@ export async function checkClientLimit(userId: string): Promise<void> {
 }
 
 export async function checkTranscriptLimit(userId: string): Promise<void> {
+  if (isAdminBypassActive(userId)) return;
   const supabase = getSupabaseServerClient();
   const tier = await getUserTier(userId, supabase);
   let usage = await getOrCreateUsageTracking(userId, supabase);
@@ -142,6 +156,7 @@ export async function checkTranscriptLimit(userId: string): Promise<void> {
 }
 
 export async function checkQueryLimit(userId: string): Promise<void> {
+  if (isAdminBypassActive(userId)) return;
   const supabase = getSupabaseServerClient();
   const tier = await getUserTier(userId, supabase);
   let usage = await getOrCreateUsageTracking(userId, supabase);
@@ -171,6 +186,9 @@ export async function incrementTranscriptCount(userId: string): Promise<void> {
     .eq('user_id', userId);
 
   if (error) {
+    Sentry.captureException(new Error(error.message), {
+      extra: { userId, type: 'increment_transcript' },
+    });
     throw new Error(`Failed to increment transcript count: ${error.message}`);
   }
 }
@@ -188,6 +206,9 @@ export async function incrementQueryCount(userId: string): Promise<void> {
     .eq('user_id', userId);
 
   if (error) {
+    Sentry.captureException(new Error(error.message), {
+      extra: { userId, type: 'increment_query' },
+    });
     throw new Error(`Failed to increment query count: ${error.message}`);
   }
 }

--- a/apps/web/src/lib/config/env.ts
+++ b/apps/web/src/lib/config/env.ts
@@ -58,6 +58,9 @@ const envSchema = z.object({
   // Alerting
   SLACK_WEBHOOK_URL: z.string().optional(),
 
+  // Dev/testing overrides
+  ADMIN_BYPASS_LIMITS: z.string().default('false'),
+
   // Service Configuration
   USE_MOCK_SERVICES: z.string().default('true'),
   NEXT_PUBLIC_USE_MOCK_SERVICES: z.string().default('true'),
@@ -99,6 +102,8 @@ export const env = validateEnv();
 // Type-safe environment configuration object
 export const config = {
   // Convert string values to appropriate types
+  adminBypassLimits:
+    env.ADMIN_BYPASS_LIMITS === 'true' && env.NODE_ENV !== 'production',
   useMockServices: env.USE_MOCK_SERVICES === 'true',
   serviceTimeout: parseInt(env.SERVICE_TIMEOUT_MS, 10),
   circuitBreakerThreshold: parseInt(env.CIRCUIT_BREAKER_THRESHOLD, 10),

--- a/docs/stories/5.1.story.md
+++ b/docs/stories/5.1.story.md
@@ -1,7 +1,7 @@
 # Story 5.1: Dodo Payments Integration & Subscription Management
 
 ## Status
-Ready for Development
+Done — PRs #56 (chore: stripe→dodo prep) + #58 (feat: billing service + routes) merged 2026-05-07. Manual QA pending (test card flow + webhook in Dodo dashboard).
 
 ## Story
 
@@ -20,19 +20,19 @@ Ready for Development
 
 ## Acceptance Criteria
 
-- [ ] `npm install dodopayments` added to `apps/web`
-- [ ] DB migration: rename `stripe_customer_id` → `dodo_customer_id`, `stripe_subscription_id` → `dodo_subscription_id` in `subscriptions` table
-- [ ] `GET /api/billing/checkout?plan=monthly|annual` → creates Dodo checkout session, redirects to `checkout_url`
-- [ ] `POST /api/billing/webhook` — verifies signature via `client.webhooks.unwrap()`, handles events:
+- [x] `npm install dodopayments` added to `apps/web`
+- [x] DB migration: rename `stripe_customer_id` → `dodo_customer_id`, `stripe_subscription_id` → `dodo_subscription_id` (migration 022)
+- [x] `GET /api/billing/checkout?plan=monthly|annual` → creates Dodo checkout session, redirects to `checkout_url`
+- [x] `POST /api/billing/webhook` — verifies signature via `client.webhooks.unwrap()`, handles events:
   - `subscription.active` → set tier='pro', store `dodo_customer_id` + `dodo_subscription_id`
   - `subscription.updated` → sync status
   - `subscription.cancelled` | `subscription.expired` → downgrade to tier='free'
   - `payment.failed` | `subscription.on_hold` → log, send notification (email stub ok for now)
-- [ ] Success redirect: `/dashboard?upgraded=true` with success toast
-- [ ] Cancel redirect: `/pricing` (user cancelled checkout)
-- [ ] `BILLING_PROVIDER=placeholder` mode untouched — all existing tests still pass
-- [ ] DB RLS: only service role key writes to `subscriptions` (no client-side writes)
-- [ ] Webhook raw body preserved for signature verification (`express.raw` equivalent in Next.js)
+- [x] Success redirect: `/dashboard?upgraded=true` with success toast
+- [x] Cancel redirect: `/pricing` (user cancelled checkout)
+- [x] `BILLING_PROVIDER=placeholder` mode untouched — all existing tests still pass
+- [x] DB RLS: only service role key writes to `subscriptions` (no client-side writes)
+- [x] Webhook raw body preserved for signature verification
 
 ## Technical Notes
 
@@ -122,13 +122,16 @@ ALTER TABLE subscriptions
 
 ## Definition of Done
 
-- [ ] Checkout flow works end-to-end in test mode (Dodo test dashboard)
-- [ ] Webhook receives and processes `subscription.active` → tier updated in DB
-- [ ] Downgrade webhook (`subscription.cancelled`) → tier reset to 'free'
-- [ ] `BILLING_PROVIDER=placeholder` still works (no regression)
-- [ ] No TypeScript errors
-- [ ] No Stripe references remain in `src/` (only docs/archive allowed)
-- [ ] Manual QA: complete the deferred tests from `docs/backlog/story-4.4-manual-qa-pending.md`
+- [x] Checkout flow works end-to-end in test mode — verified 2026-05-07 (Supabase row created with `plan=pro`)
+- [x] Webhook receives and processes `subscription.active` → tier updated in DB — verified
+- [ ] Downgrade webhook (`subscription.cancelled`) → tier reset to 'free' — **pending** (Test 2 in TEMP_PAYMENT_TESTING_TODO.md)
+- [ ] Renewal failure → `on_hold` → `past_due` — **pending** (Test 3 in TEMP_PAYMENT_TESTING_TODO.md)
+- [ ] Decline path — no DB change on failed card — **pending** (Test 1 in TEMP_PAYMENT_TESTING_TODO.md)
+- [x] `BILLING_PROVIDER=placeholder` still works (no regression) — 7 tests pass
+- [x] No TypeScript errors
+- [x] No Stripe references remain in `src/`
+
+> **Remaining edge-case tests:** See `TEMP_PAYMENT_TESTING_TODO.md` (root). 3 flows pending: decline path, cancellation, renewal failure. Delete file when all 3 pass.
 
 ## Dev Notes (Pre-Start Checklist)
 

--- a/docs/stories/5.2.story.md
+++ b/docs/stories/5.2.story.md
@@ -1,0 +1,112 @@
+# Story 5.2: Tier Enforcement — Admin Override & Hardening
+
+## Status
+Done
+
+## Story
+
+**As a** developer/admin,
+**I need** an admin bypass for tier limits during testing + hardened increment error handling,
+**so that** QA can simulate both tiers without real payments, and usage tracking doesn't silently desync.
+
+## Context
+
+Core enforcement was shipped in Story 4.4:
+- `checkClientLimit`, `checkTranscriptLimit`, `checkQueryLimit` — ✅ done
+- `incrementTranscriptCount`, `incrementQueryCount` — ✅ done
+- `GET /api/usage` endpoint — ✅ done
+- `UpgradeModal` component — ✅ done, wired into ClientForm
+
+**This story covers what remains from the Epic 5.2 spec:**
+1. Admin override for testing (bypass usage limits without real payment)
+2. Harden increment functions — currently no error check on DB update (silent failure)
+
+## Acceptance Criteria
+
+- [x] `ADMIN_BYPASS_LIMITS=true` env var skips all limit checks in `checkClientLimit`, `checkTranscriptLimit`, `checkQueryLimit`
+- [x] Bypass only active when `config.adminBypassLimits` is true (production guard baked into `env.ts` config computation)
+- [x] Bypass logs `[admin] limit check bypassed for <userId>` to console
+- [x] `incrementTranscriptCount`: throws and captures to Sentry if Supabase update returns an error
+- [x] `incrementQueryCount`: same error check
+- [x] 17 tests pass (2 new bypass tests + existing 15 all green)
+- [x] `ADMIN_BYPASS_LIMITS` documented in `apps/web/.env.example`
+
+## Technical Notes
+
+### Admin Override Options
+
+**Option A — Env var (simpler, dev-only):**
+```typescript
+// In checkUsage.ts, top of each check function:
+if (process.env.ADMIN_BYPASS_LIMITS === 'true') return;
+```
+
+**Option B — DB flag (persistent per user):**
+```sql
+ALTER TABLE users ADD COLUMN is_admin BOOLEAN DEFAULT false;
+```
+Then `checkUsage.ts` reads `users.is_admin` before applying limits.
+
+> Recommend Option A for now — simpler, no migration, dev-only use case.
+
+### Increment Hardening
+
+```typescript
+// current (silent failure):
+await supabase.from('usage_tracking').update({ transcript_count: count + 1 })
+
+// hardened:
+const { error } = await supabase.from('usage_tracking').update({ transcript_count: count + 1 })...
+if (error) {
+  Sentry.captureException(error, { extra: { userId, type: 'increment_transcript' } });
+  throw new Error(`Usage increment failed: ${error.message}`);
+}
+```
+
+## Files to Modify
+
+- `apps/web/src/lib/billing/checkUsage.ts` — add admin bypass + harden increments
+- `apps/web/src/lib/billing/__tests__/checkUsage.test.ts` — add bypass + increment error tests
+- `apps/web/.env.example` — document `ADMIN_BYPASS_LIMITS`
+
+## Dependencies
+
+- Story 4.4 (core enforcement) — ✅ done
+- Story 5.1 (Dodo Payments) — ✅ done
+
+## Estimated Effort
+
+0.5 days
+
+## Dev Agent Record
+
+**Agent Model:** claude-sonnet-4-6
+
+**Completion Notes:**
+- `config.adminBypassLimits` computation in `env.ts` already bakes in the production guard (`env.NODE_ENV !== 'production'`), so `isAdminBypassActive()` only needs to check the config flag — no double-check of `process.env.NODE_ENV` needed.
+- Sentry import added to `checkUsage.ts`; both increment functions now capture + rethrow on DB error.
+- Jest tests run from `apps/web/` directory (root-level `npx jest` uses wrong Babel context).
+
+**File List:**
+- `apps/web/src/lib/billing/checkUsage.ts` — MODIFIED (admin bypass, Sentry on increment errors)
+- `apps/web/src/lib/billing/__tests__/checkUsage.test.ts` — MODIFIED (2 bypass tests, Sentry assertions)
+- `apps/web/src/lib/config/env.ts` — MODIFIED (ADMIN_BYPASS_LIMITS schema + config.adminBypassLimits)
+- `apps/web/.env.example` — MODIFIED (ADMIN_BYPASS_LIMITS documented)
+
+## QA Results
+
+**Reviewer:** Quinn (Test Architect)
+**Date:** 2026-05-07
+**Gate Decision:** PASS
+
+| AC | Status |
+|----|--------|
+| ADMIN_BYPASS_LIMITS skips all 3 check functions | ✅ PASS |
+| Production guard baked into config.adminBypassLimits | ✅ PASS |
+| Console log on bypass | ✅ PASS |
+| incrementTranscriptCount Sentry + throw on error | ✅ PASS |
+| incrementQueryCount Sentry + throw on error | ✅ PASS |
+| 17 tests pass | ✅ PASS |
+| .env.example documented | ✅ PASS |
+
+**Manual tests required:** None — no UI, no DB migration, no new API routes. Pure server-side utility fully covered by unit tests.

--- a/docs/stories/5.6.story.md
+++ b/docs/stories/5.6.story.md
@@ -1,7 +1,7 @@
 # Story 5.6: Landing Page (Executive Coach Positioning)
 
 ## Status
-Not Started
+Done — PRs #54 + #55 merged 2026-05-03. Dark landing page shipped (design pivoted to black/green system, not beige spec). Mobile desktop-only gate added for app routes.
 
 ## Story
 
@@ -65,40 +65,15 @@ Unlimited manual upload ICF-aligned documentation
 
 ## Tasks / Subtasks
 
-- [ ] **Testimonials / Social Proof**
-  - [ ] No fake testimonials at launch — use genuine quotes only post-beta
-  - [ ] Placeholder copy until real quotes collected from beta coaches
-
-- [ ] **Page Route**
-  - [ ] Update `apps/web/src/app/(marketing)/page.tsx` (or root page, depending on routing)
-  - [ ] Ensure page is public (no auth required)
-
-- [ ] **Hero Section**
-  - [ ] H1 with coach-specific headline
-  - [ ] Subheadline
-  - [ ] CTA buttons (primary + secondary)
-  - [ ] Optional: screenshot or mockup of the app
-
-- [ ] **How It Works Section**
-  - [ ] 3-step layout (numbered, horizontal on desktop / vertical on mobile)
-  - [ ] Icons or illustrations for each step
-
-- [ ] **Features Section**
-  - [ ] 4 feature cards (2×2 grid on desktop, stacked on mobile)
-  - [ ] Icons for each feature
-
-- [ ] **Pricing Section**
-  - [ ] 2-column layout: Free | Pro
-  - [ ] All feature limits listed accurately (v3 pricing)
-  - [ ] CTA buttons that link to sign-up / Stripe checkout
-
-- [ ] **Trust Signals**
-  - [ ] 3 trust statements
-  - [ ] Simple, clean design (not badge-heavy)
-
-- [ ] **Footer**
-  - [ ] Privacy Policy, Terms, Contact links
-  - [ ] "© 2026 MeetSolis"
+- [x] **Testimonials / Social Proof** — placeholder copy, no fake testimonials
+- [x] **Page Route** — root `/` public, no auth required
+- [x] **Hero Section** — H1, subheadline, CTA buttons, animations
+- [x] **How It Works Section** — shipped
+- [x] **Features Section** — shipped
+- [x] **Pricing Section** — shipped
+- [x] **Trust Signals** — shipped
+- [x] **Footer** — Privacy Policy, Terms, Contact links
+- [x] **Mobile** — desktop-only gate added for app; landing page mobile-responsive
 
 ## Dev Notes
 


### PR DESCRIPTION
## Summary
- `ADMIN_BYPASS_LIMITS=true` env var skips all tier limit checks (dev/test only — production-guarded via `config.adminBypassLimits` in `env.ts`)
- `incrementTranscriptCount` / `incrementQueryCount` now capture to Sentry + throw on DB update error (was silent failure)
- 17 tests pass (2 new bypass tests added)
- Story 5.1 + 5.6 status docs updated to Done

## Test plan
- [x] 17 unit tests pass (`cd apps/web && npx jest src/lib/billing/__tests__/checkUsage.test.ts`)
- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] No manual QA required — no UI, no DB migration, no new API routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)