### PR TITLE
fix: exclude /api/recall/* from Clerk auth + rate limiting

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -32,6 +32,7 @@ export default clerkMiddleware(async (auth, req) => {
     req.nextUrl.pathname.startsWith('/onboarding') ||
     (req.nextUrl.pathname.startsWith('/api/') &&
       !req.nextUrl.pathname.startsWith('/api/webhooks') &&
+      !req.nextUrl.pathname.startsWith('/api/recall/') &&
       req.nextUrl.pathname !== '/api/billing/webhook');
 
   if (isProtectedRoute && !userId) {
@@ -70,6 +71,7 @@ export default clerkMiddleware(async (auth, req) => {
   if (
     req.nextUrl.pathname.startsWith('/api/') &&
     !req.nextUrl.pathname.startsWith('/api/webhooks/') &&
+    !req.nextUrl.pathname.startsWith('/api/recall/') &&
     req.nextUrl.pathname !== '/api/billing/webhook'
   ) {
     const limiterType = getRateLimiterForRoute(req.nextUrl.pathname);


### PR DESCRIPTION
## Summary
- Clerk middleware was redirecting all `/api/recall/*` requests to `/sign-in` before the route could validate its own auth (CRON_SECRET for dispatch, Svix signature for webhook)
- This meant zero API calls ever reached Recall.ai

## Changes
- `middleware.ts`: add `/api/recall/` exclusion to both the protected-route check and the rate-limiter

## Test plan
- [ ] After deploy: `curl -X POST https://meetsolis.vercel.app/api/recall/dispatch-pending -H "Authorization: Bearer <CRON_SECRET>"` should return `{"ok":true,...}` not a redirect
- [ ] Set up cron-job.org POST every 2 min with that header
- [ ] Bot should appear in meeting within 5 min of calendar event start

🤖 Generated with [Claude Code](https://claude.com/claude-code)