### PR TITLE
fix(6.2): self-heal stuck dispatches + retry button

### DIFF
--- a/apps/web/src/app/api/recall/dispatch-now/route.ts
+++ b/apps/web/src/app/api/recall/dispatch-now/route.ts
@@ -64,11 +64,37 @@ export async function POST(req: NextRequest) {
   if (evt.bot_skipped) {
     return NextResponse.json({ error: 'Bot skipped' }, { status: 400 });
   }
+
+  // Allow retry: clear stale state if previous attempt errored or stuck pending without bot_id
   if (evt.bot_status) {
-    return NextResponse.json(
-      { error: 'Bot already dispatched', bot_status: evt.bot_status },
-      { status: 409 }
-    );
+    const { data: existingSession } = await supabase
+      .from('recall_sessions')
+      .select('status, recall_bot_id, created_at')
+      .eq('calendar_event_id', evt.id)
+      .maybeSingle();
+
+    const isErrored = evt.bot_status === 'error';
+    const isStuckPending =
+      evt.bot_status === 'pending' &&
+      !existingSession?.recall_bot_id &&
+      existingSession?.created_at &&
+      Date.now() - new Date(existingSession.created_at).getTime() > 60_000;
+
+    if (isErrored || isStuckPending) {
+      await supabase
+        .from('recall_sessions')
+        .delete()
+        .eq('calendar_event_id', evt.id);
+      await supabase
+        .from('calendar_events')
+        .update({ bot_status: null })
+        .eq('id', evt.id);
+    } else {
+      return NextResponse.json(
+        { error: 'Bot already dispatched', bot_status: evt.bot_status },
+        { status: 409 }
+      );
+    }
   }
 
   // Pro + active subscription

--- a/apps/web/src/components/dashboard/UpcomingSessionsCard.tsx
+++ b/apps/web/src/components/dashboard/UpcomingSessionsCard.tsx
@@ -162,6 +162,7 @@ interface BotPillProps {
   status: string | null;
   clientId: string | null;
   eventId: string;
+  meetLink: string | null;
   isPro: boolean;
   hasClient: boolean;
 }
@@ -169,11 +170,25 @@ interface BotPillProps {
 function BotPill({
   status,
   clientId,
-  eventId: _eventId,
+  eventId,
+  meetLink,
   isPro,
   hasClient,
 }: BotPillProps) {
   const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const retryMutation = useMutation({
+    mutationFn: () => dispatchNow(eventId),
+    onSuccess: async () => {
+      toast.success('Notetaker dispatched — joining meeting');
+      if (meetLink) window.open(meetLink, '_blank', 'noopener,noreferrer');
+      await queryClient.invalidateQueries({ queryKey: ['calendar-events'] });
+    },
+    onError: err => {
+      toast.error(err instanceof Error ? err.message : 'Retry failed');
+    },
+  });
 
   const openUpload = () => {
     if (clientId) router.push(`/clients/${clientId}?upload=true`);
@@ -226,16 +241,33 @@ function BotPill({
 
   if (s === 'error') {
     return (
-      <button
-        onClick={e => {
-          e.stopPropagation();
-          openUpload();
-        }}
-        className="flex items-center gap-1 text-[11px] text-red-500 hover:underline"
-      >
-        <XCircle className="h-3 w-3" />
-        Failed — Upload manually ›
-      </button>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={e => {
+            e.stopPropagation();
+            retryMutation.mutate();
+          }}
+          disabled={retryMutation.isPending}
+          className="flex items-center gap-1 text-[11px] text-primary hover:underline disabled:opacity-50"
+        >
+          {retryMutation.isPending ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <Mic className="h-3 w-3" />
+          )}
+          Retry
+        </button>
+        <button
+          onClick={e => {
+            e.stopPropagation();
+            openUpload();
+          }}
+          className="flex items-center gap-1 text-[11px] text-red-500 hover:underline"
+        >
+          <XCircle className="h-3 w-3" />
+          Upload manually
+        </button>
+      </div>
     );
   }
 
@@ -446,6 +478,7 @@ export function UpcomingSessionsCard() {
                     status={evt.bot_status}
                     clientId={evt.client_id}
                     eventId={evt.id}
+                    meetLink={evt.meet_link}
                     isPro={isPro}
                     hasClient={isMatched}
                   />


### PR DESCRIPTION
## Summary
- dispatch-now: when previous attempt errored or stuck pending >60s without bot_id, clear stale row + reset bot_status, then proceed fresh
- BotPill error state: "Retry" button next to "Upload manually"

## Why
User hit 409 after a failed dispatch (DB had stale recall_sessions row + bot_status='error'). Needed manual SQL cleanup. Now self-heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)