### PR TITLE
fix(6.2): widen dispatch window + surface error detail

### DIFF
--- a/apps/web/src/components/dashboard/UpcomingSessionsCard.tsx
+++ b/apps/web/src/components/dashboard/UpcomingSessionsCard.tsx
@@ -71,7 +71,10 @@ async function dispatchNow(eventId: string): Promise<{ bot_id: string }> {
   });
   const body = await res.json().catch(() => ({}));
   if (!res.ok) {
-    throw new Error(body.error || 'Failed to dispatch bot');
+    const msg = body.detail
+      ? `${body.error}: ${body.detail}`
+      : body.error || 'Failed to dispatch bot';
+    throw new Error(msg);
   }
   return body;
 }
@@ -135,7 +138,7 @@ function JoinWithNotetakerButton({
   if (!isPro || !hasClient || !meetLink || botStatus) return null;
 
   const minutesToStart = differenceInMinutes(new Date(startTime), new Date());
-  if (minutesToStart < -10 || minutesToStart > 10) return null;
+  if (minutesToStart < -60 || minutesToStart > 60) return null;
 
   return (
     <Button


### PR DESCRIPTION
Widen Join-with-Notetaker visibility window from ±10min → ±60min and surface backend error detail in toast on dispatch failure. Needed for debugging 502 from Recall.ai.