### PR TITLE
fix(6.2): drop null real_time_transcription (Recall.ai 400)

### DIFF
--- a/apps/web/src/app/api/recall/dispatch-now/route.ts
+++ b/apps/web/src/app/api/recall/dispatch-now/route.ts
@@ -144,7 +144,6 @@ export async function POST(req: NextRequest) {
       bot_name: config.recall.botName,
       webhook_url: `${config.app.url}/api/recall/webhook`,
       recording_mode: 'speaker_view',
-      real_time_transcription: { destination_url: null },
     });
 
     await supabase

--- a/apps/web/src/lib/services/recall/dispatch-pending.ts
+++ b/apps/web/src/lib/services/recall/dispatch-pending.ts
@@ -137,7 +137,6 @@ export async function dispatchPendingBots(): Promise<DispatchResult> {
         bot_name: config.recall.botName,
         webhook_url: `${config.app.url}/api/recall/webhook`,
         recording_mode: 'speaker_view',
-        real_time_transcription: { destination_url: null },
       });
 
       await supabase


### PR DESCRIPTION
Recall.ai 400s on `destination_url: null`. We don't need RT transcription (Deepgram handles post-call). Omitting field fixes bot dispatch.