### PR TITLE
fix(6.2): use recording_config (recording_mode deprecated)

### DIFF
--- a/apps/web/src/app/api/recall/dispatch-now/route.ts
+++ b/apps/web/src/app/api/recall/dispatch-now/route.ts
@@ -143,7 +143,10 @@ export async function POST(req: NextRequest) {
       meeting_url: evt.meet_link as string,
       bot_name: config.recall.botName,
       webhook_url: `${config.app.url}/api/recall/webhook`,
-      recording_mode: 'speaker_view',
+      recording_config: {
+        video_mixed_layout: 'speaker_view',
+        video_mixed_mp4: {},
+      },
     });
 
     await supabase

--- a/apps/web/src/lib/services/recall/dispatch-pending.ts
+++ b/apps/web/src/lib/services/recall/dispatch-pending.ts
@@ -136,7 +136,10 @@ export async function dispatchPendingBots(): Promise<DispatchResult> {
         meeting_url: evt.meet_link as string,
         bot_name: config.recall.botName,
         webhook_url: `${config.app.url}/api/recall/webhook`,
-        recording_mode: 'speaker_view',
+        recording_config: {
+          video_mixed_layout: 'speaker_view',
+          video_mixed_mp4: {},
+        },
       });
 
       await supabase

--- a/packages/shared/src/types/recall.ts
+++ b/packages/shared/src/types/recall.ts
@@ -40,8 +40,11 @@ export interface RecallCreateBotRequest {
   meeting_url: string;
   bot_name: string;
   webhook_url: string;
-  recording_mode: 'speaker_view' | 'gallery_view' | 'audio_only';
-  real_time_transcription?: { destination_url: string | null };
+  recording_config?: {
+    video_mixed_layout?: 'speaker_view' | 'gallery_view' | 'audio_only';
+    video_mixed_mp4?: Record<string, never>;
+    audio_mixed_raw?: Record<string, never>;
+  };
 }
 
 export interface RecallCreateBotResponse {


### PR DESCRIPTION
Recall.ai ap-northeast-1 returns 400 on `recording_mode`. Switch to `recording_config.video_mixed_layout + video_mixed_mp4` for MP4 output.