### PR TITLE
fix(6.2c): recording playback, action item-meeting link, session time

### DIFF
--- a/apps/web/src/app/(dashboard)/clients/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/clients/[id]/page.tsx
@@ -162,6 +162,7 @@ export default function ClientDetailPage() {
   const pendingCount = allItems.filter(i => !i.completed).length;
   const roleCompany =
     [client.role, client.company].filter(Boolean).join(' · ') || null;
+  const sessionById = new Map(sessions.map(s => [s.id, s]));
 
   return (
     <>
@@ -332,24 +333,42 @@ export default function ClientDetailPage() {
                   {allItems
                     .filter(i => !i.completed)
                     .slice(0, 8)
-                    .map(item => (
-                      <div
-                        key={item.id}
-                        className="flex items-start gap-3 px-5 py-3.5"
-                      >
-                        <span className="mt-0.5 h-1.5 w-1.5 rounded-full bg-primary shrink-0" />
-                        <div className="flex-1 min-w-0">
-                          <p className="text-[12px] text-muted-foreground leading-relaxed">
-                            {item.description}
-                          </p>
-                          {item.assignee && (
-                            <span className="mt-1 inline-block rounded px-1.5 py-0.5 text-[9px] font-bold tracking-wide bg-primary/10 text-primary">
-                              {item.assignee === 'coach' ? 'COACH' : 'CLIENT'}
-                            </span>
-                          )}
+                    .map(item => {
+                      const fromSession = item.session_id
+                        ? sessionById.get(item.session_id)
+                        : undefined;
+                      return (
+                        <div
+                          key={item.id}
+                          className="flex items-start gap-3 px-5 py-3.5"
+                        >
+                          <span className="mt-0.5 h-1.5 w-1.5 rounded-full bg-primary shrink-0" />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-[12px] text-muted-foreground leading-relaxed">
+                              {item.description}
+                            </p>
+                            <div className="mt-1 flex items-center gap-2">
+                              {item.assignee && (
+                                <span className="inline-block rounded px-1.5 py-0.5 text-[9px] font-bold tracking-wide bg-primary/10 text-primary">
+                                  {item.assignee === 'coach'
+                                    ? 'COACH'
+                                    : 'CLIENT'}
+                                </span>
+                              )}
+                              {fromSession && (
+                                <span className="truncate text-[10px] text-foreground/35">
+                                  {fromSession.title} ·{' '}
+                                  {format(
+                                    parseISO(fromSession.session_date),
+                                    'MMM d'
+                                  )}
+                                </span>
+                              )}
+                            </div>
+                          </div>
                         </div>
-                      </div>
-                    ))}
+                      );
+                    })}
                 </div>
               )}
             </div>

--- a/apps/web/src/components/sessions/SessionAccordion.tsx
+++ b/apps/web/src/components/sessions/SessionAccordion.tsx
@@ -97,12 +97,12 @@ export function SessionAccordion({ sessions, actionItems, clientId }: Props) {
               onClick={() => setOpenId(isOpen ? null : session.id)}
               className="w-full flex items-center gap-4 px-5 py-4 text-left hover:bg-foreground/[0.02] transition-colors"
             >
-              <div className="shrink-0 w-14 text-left">
+              <div className="shrink-0 w-16 text-left">
                 <p className="text-[13px] font-semibold text-foreground/70">
                   {format(dateObj, 'MMM d')}
                 </p>
                 <p className="text-[10px] text-foreground/25">
-                  {format(dateObj, 'yyyy')}
+                  {format(parseISO(session.created_at), 'h:mm a')}
                 </p>
               </div>
 

--- a/apps/web/src/components/sessions/TranscriptAudioPlayer.tsx
+++ b/apps/web/src/components/sessions/TranscriptAudioPlayer.tsx
@@ -2,9 +2,10 @@
 
 /**
  * TranscriptAudioPlayer (Story 6.2c)
- * Native HTML5 audio player. Streams the recording directly from Recall's
- * signed URL — no metered cost. forwardRef exposes the element so a parent
- * can seek imperatively (click-to-seek transcript).
+ * Plays the meeting recording streamed directly from Recall's signed URL —
+ * no metered cost. Recall records `video_mixed_mp4`, so this uses a <video>
+ * element (an <audio> element cannot reliably load an mp4 container).
+ * forwardRef exposes the element so a parent can seek imperatively.
  */
 
 import { forwardRef } from 'react';
@@ -12,23 +13,26 @@ import { forwardRef } from 'react';
 interface Props {
   src: string;
   onTimeUpdate?: (ms: number) => void;
+  onError?: () => void;
 }
 
-export const TranscriptAudioPlayer = forwardRef<HTMLAudioElement, Props>(
-  function TranscriptAudioPlayer({ src, onTimeUpdate }, ref) {
+export const TranscriptAudioPlayer = forwardRef<HTMLVideoElement, Props>(
+  function TranscriptAudioPlayer({ src, onTimeUpdate, onError }, ref) {
     return (
-      <audio
+      <video
         ref={ref}
         src={src}
         controls
+        playsInline
         preload="metadata"
-        className="w-full"
+        className="w-full max-h-[260px] rounded-lg bg-black"
         onTimeUpdate={e =>
           onTimeUpdate?.(Math.round(e.currentTarget.currentTime * 1000))
         }
+        onError={() => onError?.()}
       >
-        Your browser does not support audio playback.
-      </audio>
+        Your browser does not support video playback.
+      </video>
     );
   }
 );

--- a/apps/web/src/components/sessions/TranscriptModal.tsx
+++ b/apps/web/src/components/sessions/TranscriptModal.tsx
@@ -111,8 +111,9 @@ function AudioTab({
   sessionId: string;
   chunks: TranscriptChunk[];
 }) {
-  const audioRef = useRef<HTMLAudioElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
   const [currentMs, setCurrentMs] = useState(0);
+  const [mediaError, setMediaError] = useState(false);
 
   const { data, isLoading, isError } = useQuery<{ audio_url: string }>({
     queryKey: ['audio-url', sessionId],
@@ -126,7 +127,7 @@ function AudioTab({
   });
 
   const handleSeek = (ms: number) => {
-    const el = audioRef.current;
+    const el = videoRef.current;
     if (!el) return;
     el.currentTime = ms / 1000;
     setCurrentMs(ms);
@@ -136,7 +137,7 @@ function AudioTab({
   if (isLoading) {
     return (
       <p className="py-8 text-center text-[12px] text-foreground/30">
-        Loading audio…
+        Loading recording…
       </p>
     );
   }
@@ -152,10 +153,25 @@ function AudioTab({
   return (
     <div className="space-y-3">
       <TranscriptAudioPlayer
-        ref={audioRef}
+        ref={videoRef}
         src={data.audio_url}
         onTimeUpdate={setCurrentMs}
+        onError={() => setMediaError(true)}
       />
+      {mediaError && (
+        <p className="text-[12px] text-foreground/40">
+          Couldn&rsquo;t play the recording here.{' '}
+          <a
+            href={data.audio_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline"
+          >
+            Open it in a new tab
+          </a>
+          .
+        </p>
+      )}
       <div className="max-h-[45vh] overflow-y-auto pr-1">
         <SyncedTranscriptView
           chunks={chunks}
@@ -211,7 +227,7 @@ export function TranscriptModal({ sessionId, open, onOpenChange }: Props) {
           <Tabs defaultValue="transcript">
             <TabsList>
               <TabsTrigger value="transcript">Transcript</TabsTrigger>
-              <TabsTrigger value="audio">Audio</TabsTrigger>
+              <TabsTrigger value="audio">Recording</TabsTrigger>
             </TabsList>
             <TabsContent value="transcript">
               <FinalTranscript session={session} />


### PR DESCRIPTION
## Summary

Follow-up fixes after live testing of Story 6.2c in production.

- **Recording playback was greyed out.** Recall records `video_mixed_mp4`; an `<audio>` element cannot reliably load an mp4 container, so the player stuck at `0:00 / 0:00`. Switched `TranscriptAudioPlayer` to a `<video>` element (handles mp4 reliably) + an `onError` fallback that links the recording to open in a new tab. Tab relabelled "Recording".
- **Action items now show their meeting.** Each item in the "Open Actions" panel displays the session title + date it came from (linkage already existed via `action_items.session_id` — it just wasn't surfaced).
- **Session history shows the time.** Accordion rows showed only the date; they now also show the meeting time (from `created_at`).

## Validation

- `type-check` clean · `next build` clean
- No schema/migration changes — safe to deploy immediately.

## Test plan

- [ ] Open a completed bot session → Recording tab → video loads, plays, scrubs
- [ ] Click a transcript line → recording seeks there, line highlights
- [ ] Open Actions panel → each item shows the meeting it came from
- [ ] Session history rows show date + time

🤖 Generated with [Claude Code](https://claude.com/claude-code)