### PR TITLE
fix(6.2c): allow Recall recording domains in CSP media-src

### DIFF
--- a/apps/web/src/lib/security/headers.ts
+++ b/apps/web/src/lib/security/headers.ts
@@ -13,7 +13,7 @@ export const securityHeaders = {
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' data: https://fonts.gstatic.com",
     "frame-src 'self' https://*.clerk.dev https://*.clerk.accounts.dev https://*.clerk.com https://clerk.meetsolis.com https://challenges.cloudflare.com https://*.hotjar.com",
-    "media-src 'self' blob:",
+    "media-src 'self' blob: https://*.recall.ai https://*.amazonaws.com",
     "worker-src 'self' blob:",
     "object-src 'none'",
     "base-uri 'self'",
@@ -56,7 +56,7 @@ export const developmentSecurityHeaders = {
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' data: https://fonts.gstatic.com",
     "frame-src 'self' https://*.clerk.dev https://*.clerk.accounts.dev https://*.clerk.com https://clerk.meetsolis.com https://challenges.cloudflare.com https://*.hotjar.com",
-    "media-src 'self' blob:",
+    "media-src 'self' blob: https://*.recall.ai https://*.amazonaws.com",
     "worker-src 'self' blob:",
   ].join('; '),
 };


### PR DESCRIPTION
## Summary

The 6.2c recording player stayed greyed out at `0:00 / 0:00`. Root cause found during QA of the 6.2 story family: the Content-Security-Policy `media-src` directive was `'self' blob:` only, so the browser **refused to load the Recall recording** (served from an S3 host) — regardless of `<audio>` vs `<video>`.

Adds `https://*.recall.ai` and `https://*.amazonaws.com` to `media-src` in both the production and development CSP blocks (`apps/web/src/lib/security/headers.ts`).

## Validation

- `type-check` clean
- Security headers test suite passes (13/13)
- Scope limited to `media-src`; no other directive changed.

## Test plan

- [ ] Completed session → Recording tab → video loads and plays (no CSP error in console)
- [ ] Click a transcript line → recording seeks + line highlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)