### PR TITLE
feat(6.3): Gladia/Deepgram bot transcription + speaker diarization

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -63,6 +63,13 @@ RECALL_WEBHOOK_SECRET=
 RECALL_BOT_NAME=MeetSolis Notetaker
 RECALL_REGION=ap-northeast-1
 
+# Gladia — Story 6.3 (bot recording re-transcription + speaker diarization)
+# Sign up at gladia.io → generate API key. Bot sessions are hardcoded to Gladia.
+GLADIA_API_KEY=
+# Webhook secret for verifying Gladia callback signatures (Gladia dashboard)
+GLADIA_WEBHOOK_SECRET=
+# TRANSCRIPTION_PROVIDER also accepts 'gladia' (manual-upload routing — Story 6.5)
+
 # Analytics - PostHog
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com

--- a/apps/web/migrations/028_gladia_transcription.sql
+++ b/apps/web/migrations/028_gladia_transcription.sql
@@ -1,0 +1,43 @@
+-- Migration 028: Gladia Transcription Pipeline (Story 6.3)
+-- Re-transcribes Recall.ai bot recordings via Gladia with speaker diarization.
+
+-- ============================================================
+-- recall_sessions — Gladia job + diarization columns
+-- ============================================================
+ALTER TABLE recall_sessions
+  ADD COLUMN IF NOT EXISTS gladia_job_id TEXT UNIQUE,
+  ADD COLUMN IF NOT EXISTS diarized_transcript JSONB,
+  ADD COLUMN IF NOT EXISTS speaker_map JSONB,
+  ADD COLUMN IF NOT EXISTS speaker_review_needed BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Extend the status CHECK to cover the Gladia lifecycle.
+ALTER TABLE recall_sessions DROP CONSTRAINT IF EXISTS recall_sessions_status_check;
+ALTER TABLE recall_sessions ADD CONSTRAINT recall_sessions_status_check
+  CHECK (status IN ('pending','joining','in_meeting','transcribing','done','error',
+                    'quota_exceeded','skipped','transcription_failed','summary_failed'));
+
+COMMENT ON COLUMN recall_sessions.gladia_job_id IS 'Gladia pre-recorded job id. UNIQUE — used for webhook lookup + submit idempotency.';
+COMMENT ON COLUMN recall_sessions.diarized_transcript IS 'Raw Gladia utterances array (DiarizedUtterance[]). Source of truth for re-formatting on speaker reassignment.';
+COMMENT ON COLUMN recall_sessions.speaker_map IS 'JSONB { "speaker_0": "Coach", "speaker_1": "Sarah Chen" }.';
+COMMENT ON COLUMN recall_sessions.speaker_review_needed IS 'True when >2 or 1 speaker detected — surfaces a dashboard review banner.';
+
+-- ============================================================
+-- sessions — provenance of the transcript
+-- sessions.recall_session_id already exists (migration 026) — do NOT re-add.
+-- ============================================================
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'manual'
+    CHECK (source IN ('manual','recall_ai'));
+
+COMMENT ON COLUMN sessions.source IS 'recall_ai = bot-transcribed (Gladia); manual = uploaded transcript.';
+
+-- ============================================================
+-- MIGRATION COMPLETE
+-- ============================================================
+DO $$
+BEGIN
+    RAISE NOTICE 'Migration 028_gladia_transcription completed';
+    RAISE NOTICE 'Extended recall_sessions: gladia_job_id, diarized_transcript, speaker_map, speaker_review_needed';
+    RAISE NOTICE 'Extended recall_sessions status CHECK: transcribing, transcription_failed, summary_failed';
+    RAISE NOTICE 'Extended sessions: source';
+END $$;

--- a/apps/web/src/app/(dashboard)/clients/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/clients/[id]/sessions/[sessionId]/page.tsx
@@ -1,17 +1,39 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { format, parseISO } from 'date-fns';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Loader2 } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import { toast, Toaster } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Session } from '@meetsolis/shared';
+import { SpeakerReviewBanner } from '@/components/sessions/SpeakerReviewBanner';
+import { SpeakerMappingEditor } from '@/components/sessions/SpeakerMappingEditor';
+
+interface SpeakerData {
+  source: string;
+  speaker_map: Record<string, string> | null;
+  speaker_review_needed: boolean;
+  review_note: string | null;
+  client_name: string | null;
+}
 
 async function fetchSession(sessionId: string): Promise<Session> {
   const res = await fetch(`/api/sessions/${sessionId}`);
   if (!res.ok) throw new Error('Failed to fetch session');
-  const data = await res.json();
-  return data.session;
+  return (await res.json()).session;
+}
+
+/** A bot session whose summary has not landed yet — poll for it. */
+function isAwaitingSummary(session: Session): boolean {
+  if (session.status === 'processing') return true;
+  return (
+    session.source === 'recall_ai' &&
+    !session.summary &&
+    session.status !== 'error'
+  );
 }
 
 function SessionDetailSkeleton() {
@@ -20,7 +42,7 @@ function SessionDetailSkeleton() {
       <div className="skeleton rounded-md mb-6 h-5 w-32" />
       <div className="skeleton rounded-md mb-2 h-8 w-64" />
       <div className="skeleton rounded-md mb-6 h-4 w-32" />
-      <div className="skeleton rounded-md h-96 w-full rounded-lg" />
+      <div className="skeleton rounded-md h-96 w-full" />
     </div>
   );
 }
@@ -38,7 +60,31 @@ export default function SessionDetailPage() {
   } = useQuery<Session>({
     queryKey: ['session', sessionId],
     queryFn: () => fetchSession(sessionId),
+    // Poll while a bot session's summary is still being generated.
+    refetchInterval: q =>
+      q.state.data && isAwaitingSummary(q.state.data) ? 4000 : false,
   });
+
+  const { data: speakers } = useQuery<SpeakerData>({
+    queryKey: ['speakers', sessionId],
+    queryFn: async () => {
+      const r = await fetch(`/api/recall/sessions/${sessionId}/speakers`);
+      if (!r.ok) throw new Error('FETCH_ERROR');
+      return r.json();
+    },
+    enabled: session?.source === 'recall_ai',
+  });
+
+  // Toast once when a regenerating summary lands.
+  const hadSummary = useRef<boolean | null>(null);
+  useEffect(() => {
+    if (!session) return;
+    const has = !!session.summary;
+    if (hadSummary.current === false && has) {
+      toast.success('Summary updated.');
+    }
+    hadSummary.current = has;
+  }, [session]);
 
   if (isLoading) return <SessionDetailSkeleton />;
 
@@ -60,10 +106,12 @@ export default function SessionDetailPage() {
   }
 
   const formattedDate = format(parseISO(session.session_date), 'MMM d, yyyy');
-  const transcriptContent = session.transcript_text ?? null;
+  const isBotSession = session.source === 'recall_ai';
+  const awaitingSummary = isAwaitingSummary(session);
 
   return (
     <div className="min-h-screen bg-background">
+      <Toaster position="top-right" duration={3000} />
       <div className="container mx-auto max-w-3xl px-4 py-8">
         <Button
           variant="ghost"
@@ -78,17 +126,58 @@ export default function SessionDetailPage() {
         <h1 className="text-2xl font-bold text-foreground">{session.title}</h1>
         <p className="mt-1 text-sm text-muted-foreground">{formattedDate}</p>
 
-        {transcriptContent ? (
-          <pre className="mt-6 whitespace-pre-wrap overflow-y-auto max-h-[70vh] rounded-lg bg-card shadow-card p-4 text-sm text-foreground font-sans">
-            {transcriptContent}
-          </pre>
-        ) : (
-          <div className="mt-6 rounded-lg bg-card shadow-card px-4 py-8 text-center">
-            <p className="text-sm text-muted-foreground">
-              No transcript text available.
-            </p>
+        {/* Speaker review (bot sessions only) */}
+        {isBotSession && speakers?.speaker_review_needed && (
+          <div className="mt-6">
+            <SpeakerReviewBanner note={speakers.review_note} />
           </div>
         )}
+        {isBotSession && (
+          <div className="mt-4">
+            <SpeakerMappingEditor sessionId={sessionId} />
+          </div>
+        )}
+
+        {/* Summary */}
+        <div className="mt-6">
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.1em] text-foreground/30">
+            Session Summary
+          </p>
+          {session.summary ? (
+            <div className="prose prose-sm max-w-none rounded-lg bg-card shadow-card p-4 text-[13px] leading-relaxed text-foreground/75 [&_p]:mb-2 [&_strong]:text-foreground">
+              <ReactMarkdown>{session.summary}</ReactMarkdown>
+            </div>
+          ) : awaitingSummary ? (
+            <div className="flex items-center gap-2 rounded-lg bg-card shadow-card px-4 py-6 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Generating summary…
+            </div>
+          ) : (
+            <div className="rounded-lg bg-card shadow-card px-4 py-6 text-center text-sm text-muted-foreground">
+              {session.status === 'error'
+                ? 'Summary generation failed. Try regenerating from the client page.'
+                : 'No summary available yet.'}
+            </div>
+          )}
+        </div>
+
+        {/* Transcript */}
+        <div className="mt-6">
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.1em] text-foreground/30">
+            Transcript
+          </p>
+          {session.transcript_text ? (
+            <pre className="whitespace-pre-wrap overflow-y-auto max-h-[60vh] rounded-lg bg-card shadow-card p-4 text-sm text-foreground font-sans">
+              {session.transcript_text}
+            </pre>
+          ) : (
+            <div className="rounded-lg bg-card shadow-card px-4 py-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                No transcript text available.
+              </p>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/api/gladia/webhook/__tests__/route.test.ts
+++ b/apps/web/src/app/api/gladia/webhook/__tests__/route.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration tests — POST /api/gladia/webhook (Story 6.3)
+ */
+
+import { POST } from '../route';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/services/transcription/verify-gladia-callback', () => ({
+  verifyGladiaCallbackToken: jest.fn(),
+}));
+jest.mock('@/lib/sessions/process-recall-transcript', () => ({
+  handleGladiaDone: jest.fn(),
+  runGladiaFailureRecovery: jest.fn(),
+}));
+
+const mockMaybeSingle = jest.fn();
+jest.mock('@/lib/supabase/server', () => ({
+  getSupabaseServerClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({ maybeSingle: mockMaybeSingle }),
+      }),
+    }),
+  }),
+}));
+
+import { verifyGladiaCallbackToken } from '@/lib/services/transcription/verify-gladia-callback';
+import {
+  handleGladiaDone,
+  runGladiaFailureRecovery,
+} from '@/lib/sessions/process-recall-transcript';
+
+const mockVerify = verifyGladiaCallbackToken as jest.Mock;
+const mockHandleDone = handleGladiaDone as jest.Mock;
+const mockFailure = runGladiaFailureRecovery as jest.Mock;
+
+function call(body: unknown, token = 'tok') {
+  const init: { method: string; body?: string } = { method: 'POST' };
+  init.body = typeof body === 'string' ? body : JSON.stringify(body);
+  return POST(
+    new NextRequest(`http://localhost/api/gladia/webhook?token=${token}`, init)
+  );
+}
+
+const SUCCESS_PAYLOAD = {
+  id: 'job-123',
+  event: 'transcription.success',
+  payload: {
+    transcription: {
+      utterances: [
+        { speaker: 0, text: 'Hello.', start: 0, end: 1, confidence: 0.9 },
+        { speaker: 1, text: 'Hi.', start: 1, end: 2, confidence: 0.9 },
+      ],
+    },
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockVerify.mockReturnValue(true);
+});
+
+describe('POST /api/gladia/webhook', () => {
+  it('rejects an invalid callback token with 401', async () => {
+    mockVerify.mockReturnValue(false);
+    const res = await call(SUCCESS_PAYLOAD);
+    expect(res.status).toBe(401);
+    expect(mockHandleDone).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed JSON with 400', async () => {
+    const res = await call('}{ not json');
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a payload missing the event discriminator with 400', async () => {
+    const res = await call({ id: 'job-123' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 without dispatching when the job id is unknown', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: null });
+    const res = await call(SUCCESS_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(mockHandleDone).not.toHaveBeenCalled();
+  });
+
+  it('on transcription.success runs the pipeline with the parsed utterances', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: { id: 'rs-1' } });
+    const res = await call(SUCCESS_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(mockHandleDone).toHaveBeenCalledWith(
+      'rs-1',
+      [
+        { speaker: 0, text: 'Hello.', start: 0, end: 1 },
+        { speaker: 1, text: 'Hi.', start: 1, end: 2 },
+      ],
+      expect.anything()
+    );
+    expect(mockFailure).not.toHaveBeenCalled();
+  });
+
+  it('on transcription.error runs failure recovery', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: { id: 'rs-1' } });
+    const res = await call({ id: 'job-123', event: 'transcription.error' });
+    expect(res.status).toBe(200);
+    expect(mockFailure).toHaveBeenCalledWith(
+      'rs-1',
+      expect.any(String),
+      expect.anything()
+    );
+    expect(mockHandleDone).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/gladia/webhook/route.ts
+++ b/apps/web/src/app/api/gladia/webhook/route.ts
@@ -1,0 +1,105 @@
+/**
+ * POST /api/gladia/webhook
+ * Gladia v2 pre-recorded callback — fires when a transcription job finishes
+ * (Story 6.3).
+ *
+ * Gladia does not sign per-job callbacks, so authenticity is a shared-secret
+ * token in the URL (`?token=`). The body discriminates on `event`:
+ *   transcription.success → diarized utterances under payload.transcription
+ *   transcription.error   → failure-recovery fallback
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSupabaseServerClient } from '@/lib/supabase/server';
+import { verifyGladiaCallbackToken } from '@/lib/services/transcription/verify-gladia-callback';
+import {
+  handleGladiaDone,
+  runGladiaFailureRecovery,
+} from '@/lib/sessions/process-recall-transcript';
+
+export const runtime = 'nodejs';
+
+// Gladia UtteranceDTO — `speaker` is only present when diarization ran, so it
+// is optional and defaults to 0. Unknown fields (words, confidence, …) strip.
+const UtteranceSchema = z.object({
+  speaker: z.number().int().nonnegative().optional().default(0),
+  text: z.string(),
+  start: z.number(),
+  end: z.number(),
+});
+
+const GladiaCallbackSchema = z.object({
+  id: z.string().min(1),
+  event: z.enum(['transcription.success', 'transcription.error']),
+  payload: z
+    .object({
+      transcription: z
+        .object({ utterances: z.array(UtteranceSchema).default([]) })
+        .optional(),
+    })
+    .optional(),
+});
+
+export async function POST(req: NextRequest) {
+  // --- 1. Authenticity: shared-secret token in the callback URL. ---
+  const token = req.nextUrl.searchParams.get('token');
+  if (!verifyGladiaCallbackToken(token)) {
+    console.warn('[gladia:webhook] invalid callback token');
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // --- 2. Parse + validate. ---
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = GladiaCallbackSchema.safeParse(json);
+  if (!parsed.success) {
+    console.warn(
+      `[gladia:webhook] payload validation failed: ${parsed.error.message}`
+    );
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const { id: jobId, event, payload } = parsed.data;
+  const supabase = getSupabaseServerClient();
+
+  // --- 3. Resolve the recall_session by Gladia job id. ---
+  const { data: rs } = await supabase
+    .from('recall_sessions')
+    .select('id')
+    .eq('gladia_job_id', jobId)
+    .maybeSingle();
+
+  if (!rs) {
+    console.warn(`[gladia:webhook] no recall_session for job ${jobId}`);
+    return NextResponse.json({ ok: true });
+  }
+
+  console.info(`[gladia:webhook] event=${event} job=${jobId}`);
+
+  // --- 4. Dispatch. Work is lightweight (DB writes + one summary chain). ---
+  try {
+    if (event === 'transcription.success') {
+      const utterances = payload?.transcription?.utterances ?? [];
+      await handleGladiaDone(rs.id, utterances, supabase);
+    } else {
+      await runGladiaFailureRecovery(
+        rs.id,
+        'Gladia reported a transcription error',
+        supabase
+      );
+    }
+  } catch (err) {
+    console.error(
+      '[gladia:webhook] processing failed:',
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/src/app/api/recall/sessions/[id]/speakers/route.ts
+++ b/apps/web/src/app/api/recall/sessions/[id]/speakers/route.ts
@@ -1,0 +1,196 @@
+/**
+ * /api/recall/sessions/[id]/speakers  ([id] = sessions.id)
+ *
+ * GET   — speaker map + review state for the session detail UI (Story 6.3).
+ * PATCH — coach-corrected speaker map → reformat transcript + re-summarize.
+ *
+ * Re-summarization is fire-and-forget: the coach gets an immediate 200 and the
+ * updated summary appears on the next poll.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { createClient } from '@supabase/supabase-js';
+import { z } from 'zod';
+import { config } from '@/lib/config/env';
+import type { DiarizedUtterance, SpeakerMap } from '@meetsolis/shared';
+import { getInternalUserId } from '@/lib/helpers/user';
+import { formatDiarizedTranscript } from '@/lib/sessions/format-diarized-transcript';
+import { runSummarize } from '@/lib/sessions/summarize-session';
+import { maybeAutoGenerateActionItems } from '@/lib/sessions/generate-action-items';
+
+export const runtime = 'nodejs';
+
+function getSupabase() {
+  return createClient(config.supabase.url!, config.supabase.serviceRoleKey!);
+}
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Labels are free text ("Custom…") but bounded — they land in transcript_text.
+const SpeakersUpdateSchema = z.object({
+  speaker_map: z.record(z.string().min(1), z.string().trim().min(1).max(80)),
+});
+
+function err(code: string, message: string, status: number) {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+/** Resolve the authenticated internal user id, or a NextResponse error. */
+async function resolveUser() {
+  const { userId: clerkUserId } = await auth();
+  if (!clerkUserId) {
+    return { error: err('UNAUTHORIZED', 'Authentication required', 401) };
+  }
+  const supabase = getSupabase();
+  const userId = await getInternalUserId(supabase, clerkUserId);
+  if (!userId) {
+    return { error: err('USER_NOT_FOUND', 'User not found', 404) };
+  }
+  return { userId, supabase };
+}
+
+/**
+ * GET — speaker map + review banner state for the session detail view.
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    if (!UUID_REGEX.test(params.id)) {
+      return err('VALIDATION_ERROR', 'Invalid session ID', 400);
+    }
+
+    const resolved = await resolveUser();
+    if (resolved.error) return resolved.error;
+    const { userId, supabase } = resolved;
+
+    const { data: session } = await supabase
+      .from('sessions')
+      .select('user_id, recall_session_id, source')
+      .eq('id', params.id)
+      .single();
+
+    if (!session || session.user_id !== userId) {
+      return err('NOT_FOUND', 'Session not found', 404);
+    }
+
+    if (!session.recall_session_id) {
+      return NextResponse.json({
+        source: session.source,
+        speaker_map: null,
+        speaker_review_needed: false,
+        review_note: null,
+        client_name: null,
+      });
+    }
+
+    const { data: rs } = await supabase
+      .from('recall_sessions')
+      .select('speaker_map, speaker_review_needed, error_reason, client_id')
+      .eq('id', session.recall_session_id)
+      .single();
+
+    const { data: client } = rs?.client_id
+      ? await supabase
+          .from('clients')
+          .select('name')
+          .eq('id', rs.client_id)
+          .single()
+      : { data: null };
+
+    return NextResponse.json({
+      source: session.source,
+      speaker_map: rs?.speaker_map ?? null,
+      speaker_review_needed: rs?.speaker_review_needed ?? false,
+      review_note: rs?.error_reason ?? null,
+      client_name: client?.name ?? null,
+    });
+  } catch (error) {
+    console.error('[speakers API] GET error:', error);
+    return err('INTERNAL_ERROR', 'An unexpected error occurred', 500);
+  }
+}
+
+/**
+ * PATCH — apply a coach-corrected speaker map, reformat the transcript, and
+ * re-run the summary pipeline asynchronously.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    if (!UUID_REGEX.test(params.id)) {
+      return err('VALIDATION_ERROR', 'Invalid session ID', 400);
+    }
+
+    const resolved = await resolveUser();
+    if (resolved.error) return resolved.error;
+    const { userId, supabase } = resolved;
+
+    const body = await request.json().catch(() => null);
+    const parsed = SpeakersUpdateSchema.safeParse(body);
+    if (!parsed.success) {
+      return err('VALIDATION_ERROR', 'Invalid speaker_map', 400);
+    }
+    const speakerMap: SpeakerMap = parsed.data.speaker_map;
+
+    const { data: session } = await supabase
+      .from('sessions')
+      .select('user_id, recall_session_id')
+      .eq('id', params.id)
+      .single();
+
+    if (!session || session.user_id !== userId) {
+      return err('NOT_FOUND', 'Session not found', 404);
+    }
+    if (!session.recall_session_id) {
+      return err('NOT_READY', 'Session is not a bot recording', 409);
+    }
+
+    const { data: rs } = await supabase
+      .from('recall_sessions')
+      .select('diarized_transcript')
+      .eq('id', session.recall_session_id)
+      .single();
+
+    const utterances = (rs?.diarized_transcript ?? []) as DiarizedUtterance[];
+    if (utterances.length === 0) {
+      return err('NOT_READY', 'No diarized transcript to re-map', 409);
+    }
+
+    // Persist the corrected map; clear the review flag.
+    await supabase
+      .from('recall_sessions')
+      .update({ speaker_map: speakerMap, speaker_review_needed: false })
+      .eq('id', session.recall_session_id);
+
+    // Reformat the transcript synchronously so it is correct immediately.
+    await supabase
+      .from('sessions')
+      .update({
+        transcript_text: formatDiarizedTranscript(utterances, speakerMap),
+        source: 'recall_ai',
+      })
+      .eq('id', params.id);
+
+    // Re-summarize fire-and-forget — the UI polls for the refreshed summary.
+    runSummarize(params.id, userId)
+      .then(status => {
+        if (status === 'complete') {
+          return maybeAutoGenerateActionItems(params.id, userId, supabase);
+        }
+      })
+      .catch(e =>
+        console.error(`[speakers API] re-summarize failed ${params.id}:`, e)
+      );
+
+    return NextResponse.json({ ok: true, speaker_map: speakerMap });
+  } catch (error) {
+    console.error('[speakers API] PATCH error:', error);
+    return err('INTERNAL_ERROR', 'An unexpected error occurred', 500);
+  }
+}

--- a/apps/web/src/app/api/recall/webhook/route.ts
+++ b/apps/web/src/app/api/recall/webhook/route.ts
@@ -11,13 +11,16 @@ import {
   updateRecallSession,
   getRecallSessionByBotId,
 } from '@/lib/services/recall/bot-status-update';
-import { processRecallRecording } from '@/lib/services/recall/process-recording';
 import { getRecallRecording } from '@/lib/services/recall/recall-client';
 import { ensureSessionRow } from '@/lib/services/recall/ensure-session';
 import { finalizeStreamingTranscript } from '@/lib/services/recall/finalize-streaming';
+import { transcribeBotRecording } from '@/lib/services/transcription/gladia-service';
 import { incrementBotSessionCount } from '@/lib/billing/checkUsage';
 
 export const runtime = 'nodejs';
+// The Deepgram fallback transcribes the recording inline (synchronous) — give
+// it headroom for long sessions. Harmless for the async Gladia path.
+export const maxDuration = 300;
 
 /**
  * Recall.ai's new account-level webhook payload structure varies:
@@ -140,12 +143,11 @@ export async function POST(req: NextRequest) {
       await incrementBotSessionCount(session.user_id).catch(err =>
         console.error('[recall:webhook] increment failed:', err)
       );
-      // Concatenate streamed chunks -> transcript_text, trigger summarization.
-      await finalizeStreamingTranscript(
-        session.id,
-        session.user_id,
-        supabase
-      ).catch(err => console.error('[recall:webhook] finalize failed:', err));
+      // Concatenate streamed chunks -> transcript_text. Summarization is
+      // deferred to the Gladia path (Story 6.3) — no eager summary here.
+      await finalizeStreamingTranscript(session.id, supabase).catch(err =>
+        console.error('[recall:webhook] finalize failed:', err)
+      );
       break;
 
     case 'bot.done':
@@ -187,32 +189,31 @@ export async function POST(req: NextRequest) {
       await updateRecallSession(botId, update, supabase);
 
       if (url) {
-        // Streaming already created the sessions row — just attach the audio
-        // URL for Phase 3 playback. Fall back to the legacy async pipeline
-        // only if no streaming session exists (missed webhook / non-bot).
+        // Streaming usually created the sessions row already; ensure it
+        // exists so Story 6.2c playback has a target even on a missed
+        // streaming webhook.
         const { data: sessionRow } = await supabase
           .from('sessions')
           .select('id')
           .eq('recall_session_id', session.id)
           .maybeSingle();
+        const sessionRowId =
+          sessionRow?.id ?? (await ensureSessionRow(session.id, supabase));
 
-        if (sessionRow) {
+        // Attach the audio URL for Story 6.2c recording playback.
+        if (sessionRowId) {
           await supabase
             .from('sessions')
             .update({ transcript_audio_url: url })
-            .eq('id', sessionRow.id);
-        } else {
-          try {
-            await processRecallRecording(
-              session.id,
-              url,
-              session.user_id,
-              supabase
-            );
-          } catch (err) {
-            console.error('[recall:webhook] processRecording failed:', err);
-          }
+            .eq('id', sessionRowId);
         }
+
+        // Re-transcribe for a diarized transcript + summary (Story 6.3).
+        // Routes to Gladia or Deepgram by config; the streaming transcript is
+        // overwritten by the diarized one.
+        await transcribeBotRecording(session.id, supabase).catch(err =>
+          console.error('[recall:webhook] transcribeBotRecording failed:', err)
+        );
       }
       break;
     }

--- a/apps/web/src/components/sessions/SpeakerMappingEditor.tsx
+++ b/apps/web/src/components/sessions/SpeakerMappingEditor.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+/**
+ * SpeakerMappingEditor (Story 6.3)
+ * Lets a coach correct Gladia's speaker → name mapping for a bot session.
+ * On confirm it PATCHes the new map; the server reformats the transcript and
+ * re-runs the summary, which the session page picks up on its next poll.
+ */
+
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import type { SpeakerMap } from '@meetsolis/shared';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface SpeakerData {
+  source: string;
+  speaker_map: SpeakerMap | null;
+  speaker_review_needed: boolean;
+  review_note: string | null;
+  client_name: string | null;
+}
+
+const CUSTOM = '__custom__';
+
+async function fetchSpeakers(sessionId: string): Promise<SpeakerData> {
+  const r = await fetch(`/api/recall/sessions/${sessionId}/speakers`);
+  if (!r.ok) throw new Error('FETCH_ERROR');
+  return r.json();
+}
+
+/** "speaker_0" → "Speaker 1" (1-based, human friendly). */
+function speakerLabel(key: string): string {
+  const n = Number(key.replace('speaker_', ''));
+  return Number.isFinite(n) ? `Speaker ${n + 1}` : key;
+}
+
+export function SpeakerMappingEditor({ sessionId }: { sessionId: string }) {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery<SpeakerData>({
+    queryKey: ['speakers', sessionId],
+    queryFn: () => fetchSpeakers(sessionId),
+  });
+
+  const initialMap = data?.speaker_map ?? null;
+  const [draft, setDraft] = useState<SpeakerMap | null>(null);
+
+  // Preset name options offered in every dropdown.
+  const presets = useMemo(() => {
+    const names = ['Coach'];
+    if (data?.client_name) names.push(data.client_name);
+    names.push('Unknown 1', 'Unknown 2');
+    return Array.from(new Set(names));
+  }, [data?.client_name]);
+
+  const mutation = useMutation({
+    mutationFn: async (speakerMap: SpeakerMap) => {
+      const r = await fetch(`/api/recall/sessions/${sessionId}/speakers`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ speaker_map: speakerMap }),
+      });
+      if (!r.ok) throw new Error('PATCH_ERROR');
+      return r.json();
+    },
+    onSuccess: (_res, speakerMap) => {
+      // Optimistic: keep the edited labels; flag review as resolved.
+      queryClient.setQueryData<SpeakerData>(['speakers', sessionId], prev =>
+        prev
+          ? { ...prev, speaker_map: speakerMap, speaker_review_needed: false }
+          : prev
+      );
+      // Session summary is regenerating server-side — let the page poll.
+      queryClient.invalidateQueries({ queryKey: ['session', sessionId] });
+      setDraft(null);
+      toast.success('Speakers confirmed — regenerating summary…');
+    },
+    onError: () => toast.error('Could not update speakers. Please try again.'),
+  });
+
+  if (isLoading) {
+    return <div className="skeleton h-24 w-full rounded-lg" />;
+  }
+  if (!initialMap || Object.keys(initialMap).length === 0) {
+    return null; // not a diarized bot session
+  }
+
+  const current = draft ?? initialMap;
+  const keys = Object.keys(current).sort();
+  const dirty = draft !== null;
+  const hasBlank = Object.values(current).some(v => !v.trim());
+
+  const setName = (key: string, value: string) => {
+    setDraft({ ...(draft ?? initialMap), [key]: value });
+  };
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.1em] text-foreground/30">
+        Speaker Labels
+      </p>
+
+      <div className="space-y-3">
+        {keys.map(key => {
+          const value = current[key];
+          const isCustom = !presets.includes(value);
+          return (
+            <div key={key} className="flex items-center gap-3">
+              <span className="w-20 shrink-0 text-[12px] text-muted-foreground">
+                {speakerLabel(key)}
+              </span>
+              <Select
+                value={isCustom ? CUSTOM : value}
+                onValueChange={v => setName(key, v === CUSTOM ? '' : v)}
+              >
+                <SelectTrigger className="h-9 w-48 text-[13px]">
+                  <SelectValue placeholder="Choose…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {presets.map(p => (
+                    <SelectItem key={p} value={p} className="text-[13px]">
+                      {p}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value={CUSTOM} className="text-[13px]">
+                    Custom…
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              {isCustom && (
+                <Input
+                  value={value}
+                  onChange={e => setName(key, e.target.value)}
+                  placeholder="Enter a name"
+                  maxLength={80}
+                  className="h-9 w-44 text-[13px]"
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {dirty && (
+        <div className="mt-4 flex items-center gap-3">
+          <Button
+            size="sm"
+            disabled={hasBlank || mutation.isPending}
+            onClick={() => mutation.mutate(current)}
+          >
+            {mutation.isPending ? 'Saving…' : 'Confirm speakers'}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={mutation.isPending}
+            onClick={() => setDraft(null)}
+          >
+            Cancel
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/sessions/SpeakerReviewBanner.tsx
+++ b/apps/web/src/components/sessions/SpeakerReviewBanner.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+/**
+ * SpeakerReviewBanner (Story 6.3)
+ * Yellow notice shown when Gladia diarization detected an unexpected number
+ * of speakers (>2 or 1) and the coach should verify the speaker labels.
+ */
+
+import { AlertTriangle } from 'lucide-react';
+
+export function SpeakerReviewBanner({ note }: { note?: string | null }) {
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+      <div className="text-[13px] leading-relaxed text-amber-200">
+        <p className="font-semibold">Please verify the speaker labels</p>
+        <p className="text-amber-200/80">
+          {note ??
+            'Multiple speakers detected. Confirm who said what below before relying on the summary.'}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/config/env.ts
+++ b/apps/web/src/lib/config/env.ts
@@ -20,10 +20,16 @@ const envSchema = z.object({
   OPENAI_API_KEY: z.string().optional(),
 
   // Transcription Provider (abstracted)
+  // 'gladia' documents the value for Story 6.5 manual-upload routing; bot
+  // sessions are hardcoded to Gladia and ignore this env var.
   TRANSCRIPTION_PROVIDER: z
-    .enum(['placeholder', 'deepgram', 'openai-whisper'])
+    .enum(['placeholder', 'deepgram', 'openai-whisper', 'gladia'])
     .default('placeholder'),
   DEEPGRAM_API_KEY: z.string().optional(),
+
+  // Gladia — Story 6.3 (bot recording re-transcription + diarization)
+  GLADIA_API_KEY: z.string().optional(),
+  GLADIA_WEBHOOK_SECRET: z.string().optional(),
 
   // Billing Provider (abstracted)
   BILLING_PROVIDER: z.enum(['placeholder', 'dodo']).default('placeholder'),
@@ -155,6 +161,12 @@ export const config = {
   transcription: {
     provider: env.TRANSCRIPTION_PROVIDER,
     deepgramApiKey: env.DEEPGRAM_API_KEY,
+  },
+
+  gladia: {
+    apiKey: env.GLADIA_API_KEY,
+    webhookSecret: env.GLADIA_WEBHOOK_SECRET,
+    baseUrl: 'https://api.gladia.io/v2',
   },
 
   billing: {

--- a/apps/web/src/lib/mail.ts
+++ b/apps/web/src/lib/mail.ts
@@ -65,3 +65,51 @@ export async function sendWelcomeEmail(email: string, name?: string) {
     return { success: false, error };
   }
 }
+
+/**
+ * Notify a coach that auto-transcription failed for a session (Story 6.3).
+ * Sent only on a hard failure with no streaming transcript to fall back on,
+ * so the coach knows to upload the recording manually.
+ */
+export async function sendTranscriptionFailedEmail(
+  email: string,
+  name: string | null,
+  clientName: string
+) {
+  const firstName = name?.split(' ')[0] || 'there';
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://meetsolis.com';
+
+  try {
+    const info = await transporter.sendMail({
+      from: `"MeetSolis" <${process.env.GMAIL_USER}>`,
+      to: email,
+      subject: `Action needed: transcription failed for ${clientName}`,
+      html: `
+        <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; color: #0f172a;">
+          <h2 style="margin-bottom: 16px;">We couldn't transcribe a session</h2>
+          <p style="color: #475569; line-height: 1.6;">
+            Hi ${firstName}, automatic transcription of your recent session with
+            <strong>${clientName}</strong> didn't go through.
+          </p>
+          <p style="color: #475569; line-height: 1.6;">
+            No transcript was captured, so there's nothing for us to summarize.
+            You can still get a summary by uploading the recording manually from
+            the client's page.
+          </p>
+          <p style="margin: 24px 0;">
+            <a href="${appUrl}/clients"
+               style="background:#0d5c63;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;font-weight:600;">
+              Upload manually
+            </a>
+          </p>
+          <p style="color: #94a3b8; font-size: 12px;">— MeetSolis</p>
+        </div>
+      `,
+    });
+    console.log('Transcription-failed email sent: %s', info.messageId);
+    return { success: true };
+  } catch (error) {
+    console.error('Error sending transcription-failed email:', error);
+    return { success: false, error };
+  }
+}

--- a/apps/web/src/lib/services/recall/finalize-streaming.ts
+++ b/apps/web/src/lib/services/recall/finalize-streaming.ts
@@ -1,20 +1,19 @@
 /**
  * Finalize a streamed transcript when a bot call ends (Story 6.2b).
  *
- * Concatenates transcript_chunks into transcript_text, marks streaming
- * complete, and triggers AI summarization directly. Skips runTranscribe —
- * the transcript already exists from live streaming.
+ * Concatenates transcript_chunks into transcript_text and marks streaming
+ * complete. Story 6.3: it no longer summarizes — the summary is produced once,
+ * by the Gladia path, on the high-quality diarized transcript (avoids a
+ * wasted AI run and a summary-then-changes UX). Between bot.call_ended and
+ * Gladia completion the session has a transcript but no summary.
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { TranscriptChunk } from '@meetsolis/shared';
 import { concatTranscriptText } from './process-transcript-chunk';
-import { runSummarize } from '@/lib/sessions/summarize-session';
-import { maybeAutoGenerateActionItems } from '@/lib/sessions/generate-action-items';
 
 export async function finalizeStreamingTranscript(
   recallSessionId: string,
-  userId: string,
   supabase: SupabaseClient
 ): Promise<void> {
   const { data: sessionRow, error } = await supabase
@@ -51,19 +50,4 @@ export async function finalizeStreamingTranscript(
       transcript_streaming_complete: true,
     })
     .eq('id', sessionRow.id);
-
-  // Fire-and-forget — generates summary + key topics + embedding, then
-  // auto-generates action items only if the user opted in (Story 6.2c).
-  runSummarize(sessionRow.id, userId)
-    .then(status => {
-      if (status === 'complete') {
-        return maybeAutoGenerateActionItems(sessionRow.id, userId, supabase);
-      }
-    })
-    .catch(err =>
-      console.error(
-        `[recall:finalize] runSummarize failed session=${sessionRow.id}:`,
-        err instanceof Error ? err.message : String(err)
-      )
-    );
 }

--- a/apps/web/src/lib/services/transcription/__tests__/deepgram-batch.test.ts
+++ b/apps/web/src/lib/services/transcription/__tests__/deepgram-batch.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests — Deepgram batch diarized transcription (Story 6.3)
+ */
+
+jest.mock('@/lib/config/env', () => ({
+  config: { transcription: { deepgramApiKey: 'dg-key' as string | undefined } },
+}));
+
+import { config } from '@/lib/config/env';
+import { transcribeRecordingWithDeepgram } from '../deepgram-batch';
+
+const setKey = (v: string | undefined) => {
+  (
+    config as { transcription: { deepgramApiKey: string | undefined } }
+  ).transcription.deepgramApiKey = v;
+};
+
+function mockFetch(ok: boolean, body: unknown) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => setKey('dg-key'));
+
+describe('transcribeRecordingWithDeepgram', () => {
+  it('maps Deepgram utterances to DiarizedUtterance[]', async () => {
+    mockFetch(true, {
+      results: {
+        utterances: [
+          { speaker: 0, transcript: 'Hello there.', start: 0, end: 1.5 },
+          { speaker: 1, transcript: 'Hi back.', start: 1.6, end: 2.4 },
+        ],
+      },
+    });
+
+    const out = await transcribeRecordingWithDeepgram('https://audio/x.mp3');
+
+    expect(out).toEqual([
+      { speaker: 0, text: 'Hello there.', start: 0, end: 1.5 },
+      { speaker: 1, text: 'Hi back.', start: 1.6, end: 2.4 },
+    ]);
+  });
+
+  it('defaults a missing speaker index to 0', async () => {
+    mockFetch(true, {
+      results: {
+        utterances: [{ transcript: 'No speaker field.', start: 0, end: 1 }],
+      },
+    });
+    const out = await transcribeRecordingWithDeepgram('https://audio/x.mp3');
+    expect(out[0].speaker).toBe(0);
+  });
+
+  it('drops blank utterances', async () => {
+    mockFetch(true, {
+      results: {
+        utterances: [
+          { speaker: 0, transcript: '   ', start: 0, end: 1 },
+          { speaker: 1, transcript: 'real', start: 1, end: 2 },
+        ],
+      },
+    });
+    const out = await transcribeRecordingWithDeepgram('https://audio/x.mp3');
+    expect(out).toHaveLength(1);
+    expect(out[0].text).toBe('real');
+  });
+
+  it('throws when no API key is configured', async () => {
+    setKey(undefined);
+    await expect(
+      transcribeRecordingWithDeepgram('https://audio/x.mp3')
+    ).rejects.toThrow('DEEPGRAM_API_KEY');
+  });
+
+  it('throws on a non-ok Deepgram response', async () => {
+    mockFetch(false, { err: 'boom' });
+    await expect(
+      transcribeRecordingWithDeepgram('https://audio/x.mp3')
+    ).rejects.toThrow('Deepgram API error 500');
+  });
+});

--- a/apps/web/src/lib/services/transcription/__tests__/gladia-service.test.ts
+++ b/apps/web/src/lib/services/transcription/__tests__/gladia-service.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests — bot transcription router (Story 6.3)
+ *
+ * Focus: the 3-way routing of transcribeBotRecording (mock / Deepgram / Gladia)
+ * and idempotency.
+ */
+
+jest.mock('@/lib/config/env', () => ({
+  config: {
+    useMockServices: false,
+    gladia: {
+      apiKey: undefined as string | undefined,
+      baseUrl: 'https://api.gladia.io/v2',
+      webhookSecret: undefined as string | undefined,
+    },
+    app: { env: 'test', url: 'http://localhost:3000' },
+  },
+}));
+
+const mockHandleDone = jest.fn();
+const mockFailure = jest.fn();
+const mockDeepgram = jest.fn();
+
+jest.mock('@/lib/sessions/process-recall-transcript', () => ({
+  handleGladiaDone: (...a: unknown[]) => mockHandleDone(...a),
+  runGladiaFailureRecovery: (...a: unknown[]) => mockFailure(...a),
+}));
+jest.mock('../deepgram-batch', () => ({
+  transcribeRecordingWithDeepgram: (...a: unknown[]) => mockDeepgram(...a),
+}));
+
+import { config } from '@/lib/config/env';
+import { transcribeBotRecording, DEEPGRAM_JOB_PREFIX } from '../gladia-service';
+
+type Cfg = {
+  useMockServices: boolean;
+  gladia: { apiKey: string | undefined };
+};
+const cfg = config as unknown as Cfg;
+
+/** Supabase stub — one recall_sessions row; records update() calls. */
+function mockSupabase(row: {
+  raw_recording_url: unknown;
+  gladia_job_id: unknown;
+}) {
+  const updates: unknown[] = [];
+  const builder: Record<string, unknown> = {
+    select: () => builder,
+    eq: () => builder,
+    maybeSingle: () => Promise.resolve({ data: row, error: null }),
+    update: (v: unknown) => {
+      updates.push(v);
+      return { eq: () => Promise.resolve({ error: null }) };
+    },
+  };
+  return { client: { from: () => builder } as never, updates };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  cfg.useMockServices = false;
+  cfg.gladia.apiKey = undefined;
+});
+
+describe('transcribeBotRecording', () => {
+  it('Deepgram path — no GLADIA key: transcribes the real audio and runs the pipeline', async () => {
+    mockDeepgram.mockResolvedValue([
+      { speaker: 0, text: 'Hi', start: 0, end: 1 },
+    ]);
+    const { client, updates } = mockSupabase({
+      raw_recording_url: 'https://audio/x.mp3',
+      gladia_job_id: null,
+    });
+
+    await transcribeBotRecording('rs-1', client);
+
+    expect(mockDeepgram).toHaveBeenCalledWith('https://audio/x.mp3');
+    expect(mockHandleDone).toHaveBeenCalledWith(
+      'rs-1',
+      [{ speaker: 0, text: 'Hi', start: 0, end: 1 }],
+      expect.anything()
+    );
+    expect(mockFailure).not.toHaveBeenCalled();
+    // Idempotency marker stored before transcription.
+    expect(updates).toContainEqual({
+      gladia_job_id: `${DEEPGRAM_JOB_PREFIX}rs-1`,
+      status: 'transcribing',
+    });
+  });
+
+  it('Deepgram path — failure routes into failure-recovery', async () => {
+    mockDeepgram.mockRejectedValue(new Error('Deepgram 500'));
+    const { client } = mockSupabase({
+      raw_recording_url: 'https://audio/x.mp3',
+      gladia_job_id: null,
+    });
+
+    await transcribeBotRecording('rs-1', client);
+
+    expect(mockHandleDone).not.toHaveBeenCalled();
+    expect(mockFailure).toHaveBeenCalledWith(
+      'rs-1',
+      expect.stringContaining('Deepgram'),
+      expect.anything()
+    );
+  });
+
+  it('mock mode — runs the fixture, never calls Deepgram or Gladia', async () => {
+    cfg.useMockServices = true;
+    const { client } = mockSupabase({
+      raw_recording_url: 'https://audio/x.mp3',
+      gladia_job_id: null,
+    });
+
+    await transcribeBotRecording('rs-1', client);
+
+    expect(mockDeepgram).not.toHaveBeenCalled();
+    expect(mockHandleDone).toHaveBeenCalled(); // fixture utterances
+  });
+
+  it('idempotent — skips when a job id is already set', async () => {
+    const { client } = mockSupabase({
+      raw_recording_url: 'https://audio/x.mp3',
+      gladia_job_id: 'deepgram-rs-1',
+    });
+
+    await transcribeBotRecording('rs-1', client);
+
+    expect(mockDeepgram).not.toHaveBeenCalled();
+    expect(mockHandleDone).not.toHaveBeenCalled();
+  });
+
+  it('skips when there is no recording URL', async () => {
+    const { client } = mockSupabase({
+      raw_recording_url: null,
+      gladia_job_id: null,
+    });
+
+    await transcribeBotRecording('rs-1', client);
+
+    expect(mockDeepgram).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/services/transcription/__tests__/verify-gladia-callback.test.ts
+++ b/apps/web/src/lib/services/transcription/__tests__/verify-gladia-callback.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit tests — Gladia callback token verification (Story 6.3)
+ *
+ * Gladia does not sign per-job callbacks; authenticity is a shared-secret
+ * token in the callback URL. This is the auth check the webhook relies on.
+ */
+
+jest.mock('@/lib/config/env', () => ({
+  config: { gladia: { webhookSecret: undefined as string | undefined } },
+}));
+
+import { config } from '@/lib/config/env';
+import { verifyGladiaCallbackToken } from '../verify-gladia-callback';
+
+const setSecret = (v: string | undefined) => {
+  (
+    config as { gladia: { webhookSecret: string | undefined } }
+  ).gladia.webhookSecret = v;
+};
+
+describe('verifyGladiaCallbackToken', () => {
+  it('skips verification when no secret is configured (dev/mock)', () => {
+    setSecret(undefined);
+    expect(verifyGladiaCallbackToken(null)).toBe(true);
+    expect(verifyGladiaCallbackToken('anything')).toBe(true);
+  });
+
+  it('accepts a matching token', () => {
+    setSecret('s3cr3t-token');
+    expect(verifyGladiaCallbackToken('s3cr3t-token')).toBe(true);
+  });
+
+  it('rejects a wrong token', () => {
+    setSecret('s3cr3t-token');
+    expect(verifyGladiaCallbackToken('wrong-token')).toBe(false);
+  });
+
+  it('rejects a missing token when a secret is set', () => {
+    setSecret('s3cr3t-token');
+    expect(verifyGladiaCallbackToken(null)).toBe(false);
+  });
+
+  it('rejects a token of different length without throwing', () => {
+    setSecret('s3cr3t-token');
+    expect(verifyGladiaCallbackToken('short')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/services/transcription/deepgram-batch.ts
+++ b/apps/web/src/lib/services/transcription/deepgram-batch.ts
@@ -1,0 +1,66 @@
+/**
+ * Deepgram batch (pre-recorded) diarized transcription (Story 6.3).
+ *
+ * The fallback transcription path for bot recordings when Gladia is not
+ * configured. Unlike DeepgramTranscriptionService — which flattens the result
+ * into a single text blob — this returns the structured per-speaker utterances
+ * the bot pipeline needs (handleGladiaDone expects DiarizedUtterance[]).
+ *
+ * Deepgram and Gladia produce the same DiarizedUtterance[] shape, so the
+ * downstream pipeline (speaker mapping, summary, reassignment UI) is identical
+ * regardless of which provider ran.
+ */
+
+import { config } from '@/lib/config/env';
+import type { DiarizedUtterance } from '@meetsolis/shared';
+
+/** Deepgram utterance shape (subset) — present when diarize + utterances on. */
+interface DeepgramUtterance {
+  speaker?: number;
+  transcript: string;
+  start: number;
+  end: number;
+}
+
+/**
+ * Transcribe a recording URL with Deepgram Nova-2, diarized.
+ * Throws if the API key is missing or the API call fails — the caller
+ * (transcribeBotRecording) routes that into the failure-recovery fallback.
+ */
+export async function transcribeRecordingWithDeepgram(
+  audioUrl: string
+): Promise<DiarizedUtterance[]> {
+  const apiKey = config.transcription.deepgramApiKey;
+  if (!apiKey) {
+    throw new Error('DEEPGRAM_API_KEY is not configured');
+  }
+
+  const res = await fetch(
+    'https://api.deepgram.com/v1/listen?model=nova-2&diarize=true&punctuate=true&smart_format=true&utterances=true',
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Token ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ url: audioUrl }),
+    }
+  );
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Deepgram API error ${res.status}: ${body}`);
+  }
+
+  const data = await res.json();
+  const utterances: DeepgramUtterance[] = data?.results?.utterances ?? [];
+
+  return utterances
+    .filter(u => u.transcript?.trim())
+    .map(u => ({
+      speaker: u.speaker ?? 0,
+      text: u.transcript,
+      start: u.start,
+      end: u.end,
+    }));
+}

--- a/apps/web/src/lib/services/transcription/gladia-fixture.ts
+++ b/apps/web/src/lib/services/transcription/gladia-fixture.ts
@@ -1,0 +1,37 @@
+/**
+ * Canned Gladia diarized transcript used in mock mode (Story 6.3).
+ *
+ * When USE_MOCK_SERVICES is true or GLADIA_API_KEY is unset, submitGladiaJob
+ * skips the real API and feeds this fixture through the same processing path
+ * the webhook would — so dev/test exercises the full pipeline end-to-end.
+ */
+
+import type { DiarizedUtterance } from '@meetsolis/shared';
+
+/** Two-speaker (coach + client) sample. Maps cleanly, no review needed. */
+export const MOCK_DIARIZED_UTTERANCES: DiarizedUtterance[] = [
+  {
+    speaker: 0,
+    text: 'Welcome back. How did the week go?',
+    start: 0,
+    end: 3.2,
+  },
+  {
+    speaker: 1,
+    text: 'Honestly, a lot better than I expected. I finally had that conversation with my manager.',
+    start: 3.5,
+    end: 9.8,
+  },
+  {
+    speaker: 0,
+    text: 'That is great to hear. What made it click this time?',
+    start: 10.1,
+    end: 13.4,
+  },
+  {
+    speaker: 1,
+    text: 'I prepared the way we discussed — I led with the outcome I wanted instead of the problem.',
+    start: 13.7,
+    end: 20.0,
+  },
+];

--- a/apps/web/src/lib/services/transcription/gladia-service.ts
+++ b/apps/web/src/lib/services/transcription/gladia-service.ts
@@ -1,0 +1,225 @@
+/**
+ * Bot recording transcription router (Story 6.3).
+ *
+ * `transcribeBotRecording` is the single entry point the Recall webhook calls
+ * once a recording is ready. It routes to one of three providers:
+ *
+ *   USE_MOCK_SERVICES=true        → canned fixture (dev / test only)
+ *   real services, no GLADIA key  → Deepgram batch (real transcription)
+ *   real services, GLADIA key set → Gladia (real transcription, diarized)
+ *
+ * All three produce a DiarizedUtterance[] that flows through the identical
+ * downstream pipeline (handleGladiaDone): speaker mapping, summary, the
+ * speaker-reassignment UI. Gladia is the optional quality upgrade — flip it on
+ * by setting GLADIA_API_KEY, no code change required.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { config } from '@/lib/config/env';
+import {
+  handleGladiaDone,
+  runGladiaFailureRecovery,
+} from '@/lib/sessions/process-recall-transcript';
+import { transcribeRecordingWithDeepgram } from './deepgram-batch';
+import { MOCK_DIARIZED_UTTERANCES } from './gladia-fixture';
+
+/** Synthetic job-id prefixes — mark which provider ran + drive idempotency. */
+export const GLADIA_MOCK_JOB_PREFIX = 'mock-gladia-';
+export const DEEPGRAM_JOB_PREFIX = 'deepgram-';
+
+/** Retry backoff for 5xx submit failures. Zeroed under test for fast specs. */
+const RETRY_DELAYS_MS =
+  config.app.env === 'test' ? [0, 0, 0] : [1000, 4000, 16000];
+
+interface GladiaSubmitResponse {
+  id: string;
+  result_url?: string;
+}
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+/**
+ * Build the Gladia callback URL. Gladia does NOT sign per-job callbacks
+ * (confirmed against Gladia v2 docs — `callback_config` callbacks are
+ * unsigned), so authenticity is enforced with a shared-secret token in the
+ * URL, which /api/gladia/webhook checks. See verify-gladia-callback.ts.
+ */
+export function buildGladiaCallbackUrl(): string {
+  const base = `${config.app.url}/api/gladia/webhook`;
+  return config.gladia.webhookSecret
+    ? `${base}?token=${encodeURIComponent(config.gladia.webhookSecret)}`
+    : base;
+}
+
+/**
+ * POST to Gladia /pre-recorded with exponential backoff on 5xx.
+ * 4xx fails immediately (a retry would not help). Throws after the last retry.
+ */
+async function submitWithRetry(
+  audioUrl: string
+): Promise<GladiaSubmitResponse> {
+  const body = JSON.stringify({
+    audio_url: audioUrl,
+    diarization: true,
+    diarization_config: { min_speakers: 2, max_speakers: 4 },
+    // `callback_url` is deprecated in Gladia v2 — use callback + callback_config.
+    callback: true,
+    callback_config: { url: buildGladiaCallbackUrl(), method: 'POST' },
+  });
+
+  let lastError = '';
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    if (attempt > 0) await sleep(RETRY_DELAYS_MS[attempt - 1]);
+
+    let res: Response;
+    try {
+      res = await fetch(`${config.gladia.baseUrl}/pre-recorded`, {
+        method: 'POST',
+        headers: {
+          'x-gladia-key': config.gladia.apiKey as string,
+          'Content-Type': 'application/json',
+        },
+        body,
+      });
+    } catch (err) {
+      // Network error — treat like a 5xx and retry.
+      lastError = err instanceof Error ? err.message : String(err);
+      continue;
+    }
+
+    if (res.ok) {
+      return (await res.json()) as GladiaSubmitResponse;
+    }
+
+    const text = await res.text().catch(() => '');
+    lastError = `Gladia ${res.status}: ${text}`;
+    // Only 5xx is retryable.
+    if (res.status < 500) break;
+  }
+
+  throw new Error(lastError || 'Gladia submit failed');
+}
+
+/** Mark the recall_session with a job id (idempotency) + transcribing status. */
+async function markTranscribing(
+  recallSessionId: string,
+  jobId: string,
+  supabase: SupabaseClient
+): Promise<void> {
+  await supabase
+    .from('recall_sessions')
+    .update({ gladia_job_id: jobId, status: 'transcribing' })
+    .eq('id', recallSessionId);
+}
+
+/** Gladia path — async: submit, store the real job id, await the callback. */
+async function submitToGladia(
+  recallSessionId: string,
+  audioUrl: string,
+  supabase: SupabaseClient
+): Promise<void> {
+  try {
+    const job = await submitWithRetry(audioUrl);
+    await markTranscribing(recallSessionId, job.id, supabase);
+    console.info(
+      `[transcribe] Gladia job ${job.id} submitted for ${recallSessionId}`
+    );
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[transcribe] Gladia submit failed ${recallSessionId}:`,
+      reason
+    );
+    await runGladiaFailureRecovery(
+      recallSessionId,
+      `Gladia submission failed: ${reason}`,
+      supabase
+    );
+  }
+}
+
+/** Deepgram path — synchronous: transcribe now, run the pipeline inline. */
+async function transcribeWithDeepgram(
+  recallSessionId: string,
+  audioUrl: string,
+  supabase: SupabaseClient
+): Promise<void> {
+  // Mark before the API call so a duplicate webhook can't double-transcribe.
+  await markTranscribing(
+    recallSessionId,
+    `${DEEPGRAM_JOB_PREFIX}${recallSessionId}`,
+    supabase
+  );
+  try {
+    const utterances = await transcribeRecordingWithDeepgram(audioUrl);
+    await handleGladiaDone(recallSessionId, utterances, supabase);
+    console.info(`[transcribe] Deepgram completed for ${recallSessionId}`);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(`[transcribe] Deepgram failed ${recallSessionId}:`, reason);
+    await runGladiaFailureRecovery(
+      recallSessionId,
+      `Deepgram transcription failed: ${reason}`,
+      supabase
+    );
+  }
+}
+
+/**
+ * Transcribe a bot recording. Routes by configuration (see file header).
+ *
+ * Idempotent: a recall_session that already has a gladia_job_id is skipped,
+ * so duplicate `recording.done` webhooks do not re-transcribe / double-charge.
+ */
+export async function transcribeBotRecording(
+  recallSessionId: string,
+  supabase: SupabaseClient
+): Promise<void> {
+  const { data: rs, error } = await supabase
+    .from('recall_sessions')
+    .select('raw_recording_url, gladia_job_id')
+    .eq('id', recallSessionId)
+    .maybeSingle();
+
+  if (error || !rs) {
+    console.error(`[transcribe] recall_session not found: ${recallSessionId}`);
+    return;
+  }
+  if (rs.gladia_job_id) {
+    console.info(
+      `[transcribe] already started for ${recallSessionId} — skipping`
+    );
+    return;
+  }
+  if (!rs.raw_recording_url) {
+    console.warn(
+      `[transcribe] no raw_recording_url for ${recallSessionId} — skipping`
+    );
+    return;
+  }
+
+  // --- Mock mode: canned fixture through the pipeline (dev / test only). ---
+  if (config.useMockServices) {
+    await markTranscribing(
+      recallSessionId,
+      `${GLADIA_MOCK_JOB_PREFIX}${recallSessionId}`,
+      supabase
+    );
+    console.info(
+      `[transcribe] mock mode — processing fixture for ${recallSessionId}`
+    );
+    await handleGladiaDone(recallSessionId, MOCK_DIARIZED_UTTERANCES, supabase);
+    return;
+  }
+
+  // --- Real transcription: Gladia when configured, else Deepgram. ---
+  if (config.gladia.apiKey) {
+    await submitToGladia(recallSessionId, rs.raw_recording_url, supabase);
+  } else {
+    await transcribeWithDeepgram(
+      recallSessionId,
+      rs.raw_recording_url,
+      supabase
+    );
+  }
+}

--- a/apps/web/src/lib/services/transcription/verify-gladia-callback.ts
+++ b/apps/web/src/lib/services/transcription/verify-gladia-callback.ts
@@ -1,0 +1,31 @@
+/**
+ * Gladia callback authenticity check (Story 6.3).
+ *
+ * Gladia v2 does NOT sign per-job `callback_config` callbacks — there is no
+ * HMAC header to verify (confirmed against Gladia's API docs + OpenAPI spec;
+ * only the separate dashboard "Webhooks" feature is Svix-signed). The
+ * documented mitigation is a shared-secret token in the callback URL.
+ *
+ * submitGladiaJob registers the callback URL with `?token=<GLADIA_WEBHOOK_SECRET>`
+ * (see buildGladiaCallbackUrl); this verifies the inbound token matches.
+ */
+
+import { timingSafeEqual } from 'crypto';
+import { config } from '@/lib/config/env';
+
+/**
+ * True when the callback request carries the expected secret token.
+ *
+ * If GLADIA_WEBHOOK_SECRET is unset (dev / mock mode) verification is skipped
+ * — there is no secret to check against. Configure it in any real deployment.
+ */
+export function verifyGladiaCallbackToken(token: string | null): boolean {
+  const expected = config.gladia.webhookSecret;
+  if (!expected) return true; // dev/mock — nothing to verify against
+  if (!token) return false;
+
+  const a = Buffer.from(token);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}

--- a/apps/web/src/lib/sessions/__tests__/format-diarized-transcript.test.ts
+++ b/apps/web/src/lib/sessions/__tests__/format-diarized-transcript.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests — diarized transcript formatter (Story 6.3)
+ */
+
+import { formatDiarizedTranscript } from '../format-diarized-transcript';
+import type { DiarizedUtterance, SpeakerMap } from '@meetsolis/shared';
+
+const MAP: SpeakerMap = { speaker_0: 'Coach', speaker_1: 'Sarah Chen' };
+
+function utt(speaker: number, text: string, start: number): DiarizedUtterance {
+  return { speaker, text, start, end: start + 1 };
+}
+
+describe('formatDiarizedTranscript', () => {
+  it('produces "[Name]: text" lines using the speaker map', () => {
+    const text = formatDiarizedTranscript(
+      [utt(0, 'Welcome back.', 0), utt(1, 'Thanks.', 2)],
+      MAP
+    );
+    expect(text).toBe('[Coach]: Welcome back.\n[Sarah Chen]: Thanks.');
+  });
+
+  it('groups consecutive utterances from the same speaker into one line', () => {
+    const text = formatDiarizedTranscript(
+      [
+        utt(0, 'Welcome back.', 0),
+        utt(0, 'How was the week?', 1),
+        utt(1, 'Good.', 2),
+      ],
+      MAP
+    );
+    expect(text).toBe(
+      '[Coach]: Welcome back. How was the week?\n[Sarah Chen]: Good.'
+    );
+  });
+
+  it('falls back to "Speaker N" when a speaker is not mapped', () => {
+    const text = formatDiarizedTranscript([utt(2, 'Who am I?', 0)], MAP);
+    expect(text).toBe('[Speaker 2]: Who am I?');
+  });
+
+  it('sorts utterances by start time', () => {
+    const text = formatDiarizedTranscript(
+      [utt(1, 'second', 5), utt(0, 'first', 0)],
+      MAP
+    );
+    expect(text).toBe('[Coach]: first\n[Sarah Chen]: second');
+  });
+
+  it('skips blank utterances', () => {
+    const text = formatDiarizedTranscript(
+      [utt(0, '  ', 0), utt(1, 'real text', 1)],
+      MAP
+    );
+    expect(text).toBe('[Sarah Chen]: real text');
+  });
+
+  it('returns an empty string for no utterances', () => {
+    expect(formatDiarizedTranscript([], MAP)).toBe('');
+  });
+});

--- a/apps/web/src/lib/sessions/__tests__/map-speakers.test.ts
+++ b/apps/web/src/lib/sessions/__tests__/map-speakers.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests — speaker ID mapping (Story 6.3)
+ */
+
+import { mapSpeakers } from '../map-speakers';
+import type { DiarizedUtterance } from '@meetsolis/shared';
+
+function utt(speaker: number, text = 'hello'): DiarizedUtterance {
+  return { speaker, text, start: speaker, end: speaker + 1 };
+}
+
+describe('mapSpeakers', () => {
+  it('Case A — exactly 2 speakers: coach + client, no review', () => {
+    const result = mapSpeakers([utt(0), utt(1), utt(0)], 'Sarah Chen');
+    expect(result.speaker_map).toEqual({
+      speaker_0: 'Coach',
+      speaker_1: 'Sarah Chen',
+    });
+    expect(result.speaker_review_needed).toBe(false);
+    expect(result.note).toBeNull();
+  });
+
+  it('Case B — >2 speakers: extras become "Unknown N", review needed', () => {
+    const result = mapSpeakers([utt(0), utt(1), utt(2), utt(3)], 'Sarah Chen');
+    expect(result.speaker_map).toEqual({
+      speaker_0: 'Coach',
+      speaker_1: 'Sarah Chen',
+      speaker_2: 'Unknown 1',
+      speaker_3: 'Unknown 2',
+    });
+    expect(result.speaker_review_needed).toBe(true);
+    expect(result.note).toContain('4 speakers');
+  });
+
+  it('Case C — 1 speaker: coach only, review needed', () => {
+    const result = mapSpeakers([utt(0), utt(0)], 'Sarah Chen');
+    expect(result.speaker_map).toEqual({ speaker_0: 'Coach' });
+    expect(result.speaker_review_needed).toBe(true);
+    expect(result.note).toContain('one voice');
+  });
+
+  it('0 speakers — empty map, review needed', () => {
+    const result = mapSpeakers([], 'Sarah Chen');
+    expect(result.speaker_map).toEqual({});
+    expect(result.speaker_review_needed).toBe(true);
+    expect(result.note).toContain('No speech');
+  });
+
+  it('assigns roles by position when speaker indices are non-contiguous', () => {
+    const result = mapSpeakers([utt(0), utt(2)], 'Sarah Chen');
+    expect(result.speaker_map).toEqual({
+      speaker_0: 'Coach',
+      speaker_2: 'Sarah Chen',
+    });
+    expect(result.speaker_review_needed).toBe(false);
+  });
+});

--- a/apps/web/src/lib/sessions/__tests__/process-recall-transcript.test.ts
+++ b/apps/web/src/lib/sessions/__tests__/process-recall-transcript.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests — Gladia failure-recovery fallback (Story 6.3)
+ */
+
+import {
+  runGladiaFailureRecovery,
+  handleGladiaDone,
+} from '../process-recall-transcript';
+import type { DiarizedUtterance } from '@meetsolis/shared';
+
+const mockRunSummarize = jest.fn();
+const mockMaybeAuto = jest.fn();
+const mockSendFailEmail = jest.fn().mockResolvedValue({ success: true });
+
+jest.mock('../summarize-session', () => ({
+  runSummarize: (...a: unknown[]) => mockRunSummarize(...a),
+}));
+jest.mock('../generate-action-items', () => ({
+  maybeAutoGenerateActionItems: (...a: unknown[]) => mockMaybeAuto(...a),
+}));
+jest.mock('@/lib/mail', () => ({
+  sendTranscriptionFailedEmail: (...a: unknown[]) => mockSendFailEmail(...a),
+}));
+
+/**
+ * Minimal Supabase stub. `responses` maps a table name to a FIFO queue of
+ * `{ data }` consumed by single()/maybeSingle(). update().eq() always resolves.
+ */
+function mockSupabase(responses: Record<string, Array<{ data: unknown }>>) {
+  const updates: Array<{ table: string; values: unknown }> = [];
+  const from = (table: string) => {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: () => builder,
+      maybeSingle: () =>
+        Promise.resolve(responses[table]?.shift() ?? { data: null }),
+      single: () =>
+        Promise.resolve(responses[table]?.shift() ?? { data: null }),
+      update: (values: unknown) => {
+        updates.push({ table, values });
+        return { eq: () => Promise.resolve({ error: null }) };
+      },
+    };
+    return builder;
+  };
+  return { client: { from } as never, updates };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('runGladiaFailureRecovery', () => {
+  it('degraded path — summarizes the streaming transcript when one exists', async () => {
+    mockRunSummarize.mockResolvedValue('complete');
+    const { client, updates } = mockSupabase({
+      recall_sessions: [{ data: { user_id: 'u1', client_id: 'c1' } }],
+      sessions: [{ data: { id: 's1', transcript_text: 'streamed words' } }],
+    });
+
+    await runGladiaFailureRecovery('rs1', 'submit 5xx', client);
+
+    // Summarized the existing streaming transcript…
+    expect(mockRunSummarize).toHaveBeenCalledWith('s1', 'u1');
+    expect(mockMaybeAuto).toHaveBeenCalled();
+    // …and marked the recall_session done (degraded diarization, still useful).
+    expect(updates).toContainEqual({
+      table: 'recall_sessions',
+      values: { status: 'done' },
+    });
+    // No coach email — they still got a summary.
+    expect(mockSendFailEmail).not.toHaveBeenCalled();
+  });
+
+  it('hard failure — no transcript: marks transcription_failed and emails the coach', async () => {
+    const { client, updates } = mockSupabase({
+      recall_sessions: [{ data: { user_id: 'u1', client_id: 'c1' } }],
+      sessions: [{ data: null }],
+      users: [{ data: { email: 'coach@example.com', name: 'Pat Coach' } }],
+      clients: [{ data: { name: 'Sarah Chen' } }],
+    });
+
+    await runGladiaFailureRecovery('rs1', 'submit 5xx', client);
+
+    expect(mockRunSummarize).not.toHaveBeenCalled();
+    expect(updates).toContainEqual({
+      table: 'recall_sessions',
+      values: { status: 'transcription_failed', error_reason: 'submit 5xx' },
+    });
+    expect(mockSendFailEmail).toHaveBeenCalledWith(
+      'coach@example.com',
+      'Pat Coach',
+      'Sarah Chen'
+    );
+  });
+
+  it('hard failure — empty streaming transcript counts as no transcript', async () => {
+    const { client, updates } = mockSupabase({
+      recall_sessions: [{ data: { user_id: 'u1', client_id: 'c1' } }],
+      sessions: [{ data: { id: 's1', transcript_text: '   ' } }],
+      users: [{ data: { email: 'coach@example.com', name: null } }],
+      clients: [{ data: { name: 'Sarah Chen' } }],
+    });
+
+    await runGladiaFailureRecovery('rs1', 'gladia error', client);
+
+    expect(mockRunSummarize).not.toHaveBeenCalled();
+    expect(updates).toContainEqual({
+      table: 'recall_sessions',
+      values: { status: 'transcription_failed', error_reason: 'gladia error' },
+    });
+  });
+});
+
+describe('handleGladiaDone', () => {
+  const UTTERANCES: DiarizedUtterance[] = [
+    { speaker: 0, text: 'Welcome back.', start: 0, end: 2 },
+    { speaker: 1, text: 'Thanks.', start: 2, end: 3 },
+  ];
+
+  it('updates the existing sessions row + runs summary — no new row created', async () => {
+    mockRunSummarize.mockResolvedValue('complete');
+    const { client, updates } = mockSupabase({
+      recall_sessions: [
+        { data: { client_id: 'c1' } }, // handleGladiaDone client lookup
+        {
+          data: {
+            user_id: 'u1',
+            diarized_transcript: UTTERANCES,
+            speaker_map: { speaker_0: 'Coach', speaker_1: 'Sarah Chen' },
+          },
+        }, // processRecallTranscript reload
+      ],
+      clients: [{ data: { name: 'Sarah Chen' } }],
+      sessions: [{ data: { id: 's1' } }], // existing row found — no insert
+    });
+
+    await handleGladiaDone('rs1', UTTERANCES, client);
+
+    // Diarized transcript written to the EXISTING session row.
+    const sessionUpdate = updates.find(u => u.table === 'sessions');
+    expect(sessionUpdate).toBeDefined();
+    const values = sessionUpdate!.values as Record<string, string>;
+    expect(values.source).toBe('recall_ai');
+    expect(values.transcript_text).toContain('[Coach]: Welcome back.');
+    expect(values.transcript_text).toContain('[Sarah Chen]: Thanks.');
+
+    // Summary ran on the resolved session.
+    expect(mockRunSummarize).toHaveBeenCalledWith('s1', 'u1');
+
+    // recall_session finalized: done + raw audio URL nulled.
+    expect(updates).toContainEqual({
+      table: 'recall_sessions',
+      values: { status: 'done', raw_recording_url: null },
+    });
+  });
+
+  it('marks summary_failed when summarization errors', async () => {
+    mockRunSummarize.mockResolvedValue('error');
+    const { client, updates } = mockSupabase({
+      recall_sessions: [
+        { data: { client_id: 'c1' } },
+        {
+          data: {
+            user_id: 'u1',
+            diarized_transcript: UTTERANCES,
+            speaker_map: { speaker_0: 'Coach', speaker_1: 'Sarah Chen' },
+          },
+        },
+      ],
+      clients: [{ data: { name: 'Sarah Chen' } }],
+      sessions: [{ data: { id: 's1' } }],
+    });
+
+    await handleGladiaDone('rs1', UTTERANCES, client);
+
+    expect(updates).toContainEqual({
+      table: 'recall_sessions',
+      values: { status: 'summary_failed', raw_recording_url: null },
+    });
+  });
+});

--- a/apps/web/src/lib/sessions/format-diarized-transcript.ts
+++ b/apps/web/src/lib/sessions/format-diarized-transcript.ts
@@ -1,0 +1,53 @@
+/**
+ * Diarized transcript formatter (Story 6.3).
+ *
+ * Turns Gladia utterances + a speaker map into the plain-text transcript
+ * stored on sessions.transcript_text and fed to the summary pipeline:
+ *
+ *   [Coach]: Welcome back, Sarah. How did the week go?
+ *   [Sarah Chen]: Honestly, a lot better than I expected...
+ *
+ * Consecutive utterances from the same speaker are merged into one line so
+ * the summarizer sees natural turn-taking rather than fragmented chunks.
+ */
+
+import type { DiarizedUtterance, SpeakerMap } from '@meetsolis/shared';
+import { speakerKey } from '@meetsolis/shared';
+
+/** Display label for a speaker index — mapped name, else "Speaker N". */
+function label(speaker: number, speakerMap: SpeakerMap): string {
+  return speakerMap[speakerKey(speaker)] ?? `Speaker ${speaker}`;
+}
+
+export function formatDiarizedTranscript(
+  utterances: DiarizedUtterance[],
+  speakerMap: SpeakerMap
+): string {
+  if (utterances.length === 0) return '';
+
+  // Gladia returns utterances in order, but sort defensively on start time.
+  const sorted = [...utterances].sort((a, b) => a.start - b.start);
+
+  const lines: string[] = [];
+  let currentSpeaker: number | null = null;
+  let buffer: string[] = [];
+
+  const flush = () => {
+    if (currentSpeaker === null || buffer.length === 0) return;
+    lines.push(`[${label(currentSpeaker, speakerMap)}]: ${buffer.join(' ')}`);
+    buffer = [];
+  };
+
+  for (const u of sorted) {
+    const text = u.text.trim();
+    if (!text) continue;
+    if (u.speaker !== currentSpeaker) {
+      flush();
+      currentSpeaker = u.speaker;
+    }
+    buffer.push(text);
+  }
+  flush();
+
+  return lines.join('\n');
+}

--- a/apps/web/src/lib/sessions/map-speakers.ts
+++ b/apps/web/src/lib/sessions/map-speakers.ts
@@ -1,0 +1,79 @@
+/**
+ * Speaker ID mapping (Story 6.3).
+ *
+ * Gladia returns 0-based speaker indices. Coaching sessions are coach + client,
+ * so the lowest-index speaker is assumed to be the coach and the next the
+ * client. >2 or 1 speaker is unexpected — flag it for coach review.
+ *
+ * Pure function — DB lookup of the client name happens in the caller.
+ */
+
+import type { DiarizedUtterance, SpeakerMap } from '@meetsolis/shared';
+import { speakerKey } from '@meetsolis/shared';
+
+export interface SpeakerMappingResult {
+  speaker_map: SpeakerMap;
+  speaker_review_needed: boolean;
+  /** Dashboard note when something looks off (e.g. only one voice). null = clean. */
+  note: string | null;
+}
+
+/** Distinct speaker indices present in the utterances, ascending. */
+function distinctSpeakers(utterances: DiarizedUtterance[]): number[] {
+  return Array.from(new Set(utterances.map(u => u.speaker))).sort(
+    (a, b) => a - b
+  );
+}
+
+/**
+ * Map Gladia speaker indices to display names.
+ *
+ *  - 2 speakers  → speaker_0 "Coach", speaker_1 <client>. No review.
+ *  - >2 speakers → extra speakers become "Unknown 1", "Unknown 2", … Review.
+ *  - 1 speaker   → speaker_0 "Coach". Review (likely a recording issue).
+ *  - 0 speakers  → empty map. Review.
+ */
+export function mapSpeakers(
+  utterances: DiarizedUtterance[],
+  clientName: string
+): SpeakerMappingResult {
+  const speakers = distinctSpeakers(utterances);
+  const speaker_map: SpeakerMap = {};
+
+  speakers.forEach((idx, position) => {
+    if (position === 0) {
+      speaker_map[speakerKey(idx)] = 'Coach';
+    } else if (position === 1) {
+      speaker_map[speakerKey(idx)] = clientName;
+    } else {
+      speaker_map[speakerKey(idx)] = `Unknown ${position - 1}`;
+    }
+  });
+
+  if (speakers.length === 2) {
+    return { speaker_map, speaker_review_needed: false, note: null };
+  }
+
+  if (speakers.length === 1) {
+    return {
+      speaker_map,
+      speaker_review_needed: true,
+      note: 'Only one voice detected — verify recording quality.',
+    };
+  }
+
+  if (speakers.length === 0) {
+    return {
+      speaker_map,
+      speaker_review_needed: true,
+      note: 'No speech detected in the recording.',
+    };
+  }
+
+  // >2 speakers
+  return {
+    speaker_map,
+    speaker_review_needed: true,
+    note: `${speakers.length} speakers detected — please verify the labels.`,
+  };
+}

--- a/apps/web/src/lib/sessions/process-recall-transcript.ts
+++ b/apps/web/src/lib/sessions/process-recall-transcript.ts
@@ -1,0 +1,237 @@
+/**
+ * Bridge from Gladia diarized output into the existing summary pipeline
+ * (Story 6.3).
+ *
+ * Story 6.2b already created the `sessions` row and streamed a live transcript
+ * into it. Gladia re-transcribes the recording for a high-quality diarized
+ * transcript — this module overwrites `sessions.transcript_text` with it and
+ * re-runs the summary chain. The streaming transcript stays the live view;
+ * Gladia produces the final one.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { DiarizedUtterance, SpeakerMap } from '@meetsolis/shared';
+import { runSummarize } from '@/lib/sessions/summarize-session';
+import { maybeAutoGenerateActionItems } from '@/lib/sessions/generate-action-items';
+import { ensureSessionRow } from '@/lib/services/recall/ensure-session';
+import { formatDiarizedTranscript } from '@/lib/sessions/format-diarized-transcript';
+import { mapSpeakers } from '@/lib/sessions/map-speakers';
+import { sendTranscriptionFailedEmail } from '@/lib/mail';
+
+/** Resolve the `sessions` row id for a bot session, creating it if missing. */
+async function resolveSessionId(
+  recallSessionId: string,
+  supabase: SupabaseClient
+): Promise<string | null> {
+  const { data: row } = await supabase
+    .from('sessions')
+    .select('id')
+    .eq('recall_session_id', recallSessionId)
+    .maybeSingle();
+  if (row) return row.id as string;
+  return ensureSessionRow(recallSessionId, supabase);
+}
+
+/**
+ * Re-format the diarized transcript with the current speaker map and re-run
+ * the summary + action-item chain. Shared by the Gladia webhook (initial run)
+ * and the speaker-reassignment endpoint (coach-corrected re-run).
+ *
+ * Returns the summary status so callers can mark recall_sessions accordingly.
+ */
+export async function regenerateFromDiarized(
+  sessionId: string,
+  userId: string,
+  utterances: DiarizedUtterance[],
+  speakerMap: SpeakerMap,
+  supabase: SupabaseClient
+): Promise<'complete' | 'error' | 'skipped'> {
+  const transcriptText = formatDiarizedTranscript(utterances, speakerMap);
+
+  await supabase
+    .from('sessions')
+    .update({ transcript_text: transcriptText, source: 'recall_ai' })
+    .eq('id', sessionId);
+
+  const status = await runSummarize(sessionId, userId);
+  if (status === 'complete') {
+    await maybeAutoGenerateActionItems(sessionId, userId, supabase);
+  }
+  return status;
+}
+
+/**
+ * Process a completed Gladia transcript: overwrite the streaming transcript
+ * with the diarized one, then summarize. Reads diarized_transcript +
+ * speaker_map already stored on recall_sessions.
+ *
+ * Returns the summary status; the caller owns the recall_sessions status.
+ */
+export async function processRecallTranscript(
+  recallSessionId: string,
+  supabase: SupabaseClient
+): Promise<'complete' | 'error' | 'skipped'> {
+  const { data: rs, error } = await supabase
+    .from('recall_sessions')
+    .select('user_id, diarized_transcript, speaker_map')
+    .eq('id', recallSessionId)
+    .maybeSingle();
+
+  if (error || !rs) {
+    console.error(
+      `[recall:process-transcript] recall_session not found: ${recallSessionId}`
+    );
+    return 'error';
+  }
+
+  const utterances = (rs.diarized_transcript ?? []) as DiarizedUtterance[];
+  const speakerMap = (rs.speaker_map ?? {}) as SpeakerMap;
+
+  const sessionId = await resolveSessionId(recallSessionId, supabase);
+  if (!sessionId) {
+    console.error(
+      `[recall:process-transcript] could not resolve sessions row for ${recallSessionId}`
+    );
+    return 'error';
+  }
+
+  return regenerateFromDiarized(
+    sessionId,
+    rs.user_id,
+    utterances,
+    speakerMap,
+    supabase
+  );
+}
+
+/**
+ * Full handler for a successful Gladia transcription. Stores the diarized
+ * transcript + speaker map, runs the summary pipeline, then finalizes the
+ * recall_sessions row. Called by the Gladia webhook (`status:'done'`) and the
+ * mock-mode submit path.
+ */
+export async function handleGladiaDone(
+  recallSessionId: string,
+  utterances: DiarizedUtterance[],
+  supabase: SupabaseClient
+): Promise<void> {
+  const { data: rs } = await supabase
+    .from('recall_sessions')
+    .select('client_id')
+    .eq('id', recallSessionId)
+    .maybeSingle();
+
+  if (!rs) {
+    console.error(
+      `[recall:gladia-done] recall_session not found: ${recallSessionId}`
+    );
+    return;
+  }
+
+  const { data: client } = await supabase
+    .from('clients')
+    .select('name')
+    .eq('id', rs.client_id)
+    .single();
+
+  const mapping = mapSpeakers(utterances, client?.name ?? 'Client');
+
+  await supabase
+    .from('recall_sessions')
+    .update({
+      diarized_transcript: utterances,
+      speaker_map: mapping.speaker_map,
+      speaker_review_needed: mapping.speaker_review_needed,
+      error_reason: mapping.note,
+    })
+    .eq('id', recallSessionId);
+
+  const status = await processRecallTranscript(recallSessionId, supabase);
+
+  // Gladia transcribed successfully — the raw audio signed URL is now stale.
+  // 'summary_failed' lets the coach retry the summary from the dashboard.
+  await supabase
+    .from('recall_sessions')
+    .update({
+      status: status === 'error' ? 'summary_failed' : 'done',
+      raw_recording_url: null,
+    })
+    .eq('id', recallSessionId);
+}
+
+/**
+ * Failure-recovery fallback — invoked when Gladia submission fails 3× or the
+ * Gladia webhook reports `status:'error'`.
+ *
+ *  - If a streaming transcript exists → summarize that instead (degraded
+ *    diarization, but the coach still gets a summary). recall_sessions → 'done'.
+ *  - Otherwise → recall_sessions → 'transcription_failed'; email the coach so
+ *    they can fall back to a manual upload.
+ */
+export async function runGladiaFailureRecovery(
+  recallSessionId: string,
+  reason: string,
+  supabase: SupabaseClient
+): Promise<void> {
+  const { data: rs } = await supabase
+    .from('recall_sessions')
+    .select('user_id, client_id')
+    .eq('id', recallSessionId)
+    .maybeSingle();
+
+  if (!rs) {
+    console.error(
+      `[recall:fallback] recall_session not found: ${recallSessionId}`
+    );
+    return;
+  }
+
+  const { data: sessionRow } = await supabase
+    .from('sessions')
+    .select('id, transcript_text')
+    .eq('recall_session_id', recallSessionId)
+    .maybeSingle();
+
+  const streamingText = sessionRow?.transcript_text?.trim();
+
+  if (sessionRow && streamingText) {
+    // Degraded path — summarize the streaming transcript.
+    console.warn(
+      `[recall:fallback] Gladia failed (${reason}) — summarizing streaming transcript for ${recallSessionId}`
+    );
+    const status = await runSummarize(sessionRow.id, rs.user_id);
+    if (status === 'complete') {
+      await maybeAutoGenerateActionItems(sessionRow.id, rs.user_id, supabase);
+    }
+    await supabase
+      .from('recall_sessions')
+      .update({ status: 'done' })
+      .eq('id', recallSessionId);
+    return;
+  }
+
+  // No transcript at all — hard failure. Notify the coach.
+  await supabase
+    .from('recall_sessions')
+    .update({ status: 'transcription_failed', error_reason: reason })
+    .eq('id', recallSessionId);
+
+  const [{ data: user }, { data: client }] = await Promise.all([
+    supabase.from('users').select('email, name').eq('id', rs.user_id).single(),
+    supabase.from('clients').select('name').eq('id', rs.client_id).single(),
+  ]);
+
+  if (user?.email) {
+    await sendTranscriptionFailedEmail(
+      user.email,
+      user.name ?? null,
+      client?.name ?? 'your client'
+    ).catch(err =>
+      console.error('[recall:fallback] failure email send failed:', err)
+    );
+  }
+
+  console.error(
+    `[recall:fallback] transcription_failed for ${recallSessionId}: ${reason}`
+  );
+}

--- a/backlog/gladia-activation.md
+++ b/backlog/gladia-activation.md
@@ -1,0 +1,53 @@
+# Gladia — Built, Dormant, Activate When Needed
+
+**Status:** Fully implemented in Story 6.3 (2026-05-18). **Not active.** MVP runs on Deepgram.
+**This is not a backlog task** — there is no code work left. This is an activation runbook.
+
+## What's already done
+
+Story 6.3 shipped the complete Gladia transcription pipeline. Bot recordings are
+re-transcribed into diarized transcripts (accurate "who said what"), speakers are
+mapped to coach/client, and the AI summary is regenerated from the diarized text.
+
+Bot transcription routes through a **3-way provider router** (`transcribeBotRecording`
+in `apps/web/src/lib/services/transcription/gladia-service.ts`):
+
+| Config | Provider used |
+|--------|---------------|
+| `USE_MOCK_SERVICES=true` | Fixture (dev/test only) |
+| real services, **no** `GLADIA_API_KEY` | **Deepgram batch** ← current MVP setting |
+| real services, `GLADIA_API_KEY` set | **Gladia** |
+
+Everything downstream — speaker mapping, the speaker-reassignment UI, summary,
+action items — is identical for both providers. They both produce the same
+`DiarizedUtterance[]` shape.
+
+## Current MVP behavior (Gladia OFF)
+
+- `GLADIA_API_KEY` is intentionally left blank.
+- Bot recordings are transcribed by **Deepgram** (diarized) — real transcription
+  of the real meeting audio. No mock data.
+- `/api/gladia/webhook` route exists but is dormant — never hit while Gladia is off.
+- Migration `028_gladia_transcription.sql` is already applied to the database.
+
+## How to activate Gladia later (no code changes)
+
+When/if Deepgram's speaker separation isn't good enough:
+
+1. Sign up at gladia.io → generate an API key (+ a webhook secret of your choice).
+2. In Vercel project env vars, set:
+   - `GLADIA_API_KEY` = the Gladia key
+   - `GLADIA_WEBHOOK_SECRET` = any strong random string (used as the callback
+     URL token — Gladia does not sign callbacks, so this is the auth check)
+3. Redeploy (or it picks up on the next deploy).
+
+That's it. The router automatically switches bot transcription to Gladia. No code
+change, no PR.
+
+### Notes
+- Cost when activated: ~$0.61–0.75/hr of audio (~$17.50/coach/mo at 25 sessions),
+  vs ~$6.50/coach/mo on Deepgram.
+- Gladia is HIPAA/SOC2 — request a BAA from Gladia if a coach asks.
+- The callback URL Gladia must reach is `https://<app-domain>/api/gladia/webhook`
+  — it is registered automatically per job; no Gladia dashboard webhook setup needed.
+- To turn Gladia back off: clear `GLADIA_API_KEY` → router falls back to Deepgram.

--- a/docs/stories/6.3.story.md
+++ b/docs/stories/6.3.story.md
@@ -1,264 +1,301 @@
 # Story 6.3: Gladia Transcription Pipeline + Speaker Diarization
 
 ## Status
-Ready for Dev
+Ready for Review
 
-## Locked Decisions (2026-05-11)
+## Correction Note (2026-05-17 — Sprint Change Proposal applied)
+
+This story was drafted before Story 6.2b (live streaming transcription) and 6.2c (audio playback) shipped. PM correct-course revised it against the **actual** codebase. Summary of what changed and why:
+
+| # | Original assumption | Reality | Fix applied |
+|---|---|---|---|
+| 1 | Bot audio is untranscribed; Gladia is the only transcription path | 6.2b already transcribes bot audio via Recall streaming → `transcript_text` + summary | Gladia now **replaces** the streaming transcript with a diarized one, then re-summarizes. Story reframed. |
+| 2 | `summarize-session.ts` takes raw text + `{client_id, user_id, source}` and **creates** a `sessions` row | `runSummarize(sessionId, userId)` updates an **existing** row; reads `transcript_text` off it; does not create rows, take text, or do action items | Gladia path **updates the existing streaming `sessions` row**, then calls `runSummarize` with the real signature. |
+| 3 | `sessions.recall_session_id` is a new column | Already exists + UNIQUE index (migration 026) | Migration only adds `sessions.source`. A 2nd insert would hit the UNIQUE constraint → removed double-insert. |
+| 4 | Trigger Gladia on `bot.call_ended` | `raw_recording_url` is set on `recording.done`, not `bot.call_ended` | Gladia triggered from the `recording.done` webhook branch. |
+| 5 | Delete the Recall recording after Gladia completes | 6.2c playback (`cdc7f19`) depends on the Recall recording existing | **Do NOT delete; no copy-to-storage.** Rely on Recall's 7-day GC. Playback works for 7d, then auto-purged. |
+| 6 | Provider routing lives in `summarize-session.ts` | That file doesn't transcribe. Manual-upload routing is Story 6.5 (already in Out of Scope) | Routing AC trimmed to 6.3 scope only. |
+| 7 | `/api/gladia/transcribe` internal route + fire-and-forget POST | Codebase calls services directly from the webhook (`finalizeStreamingTranscript`, `processRecallRecording`) | No internal route. Webhook calls `gladia-service.submitJob()` directly. Removes an unauthenticated route. |
+| 8 | `recall_sessions.session_id` FK column | Redundant with existing UNIQUE `sessions.recall_session_id` | Column dropped from migration. |
+
+## Locked Decisions (2026-05-11, amended 2026-05-17)
+
 - **Transcription provider for bot sessions:** Gladia (HIPAA/SOC2, 2–3x fewer diarization errors than Deepgram). Manual uploads stay on Deepgram.
-- **Diarization config:** `min_speakers=2`, `max_speakers=4`. 2 covers coach + client (always), 4 covers group sessions without over-splitting.
-- **Async pattern:** Gladia webhook callback preferred. Fallback: polling every 10s, max 30 attempts (5-min ceiling). Polling deferred until we confirm webhooks work.
-- **Speaker mapping defaults:** Speaker 0 → `"Coach"`, Speaker 1 → matched `Client Card.name`. Stored in `recall_sessions.speaker_map` JSONB. Coach can manually reassign.
-- **Multi-speaker flag:** if Gladia returns >2 distinct speakers → `speaker_review_needed = true` → surface in dashboard banner.
-- **Manual speaker reassignment:** edit dropdown per speaker label in session view → click "Confirm speakers" → re-runs `summarize-session.ts` with corrected labels. AI summary, action items, embeddings all regenerated.
-- **Source field:** new `sessions.source` column: `"recall_ai"` (bot) | `"manual"` (upload). Distinguishes path of origin but downstream summary pipeline is identical.
-- **Transcription provider routing:** `TRANSCRIPTION_PROVIDER` env var (`deepgram` | `gladia` | `mock`) is a SYSTEM override for dev/staging. User-facing routing is: bot sessions → Gladia (hardcoded), manual uploads → user preference (Deepgram default, Gladia opt-in from Story 6.5).
-- **Pipeline integration:** Gladia output formatted as `[Coach]: text...\n[Sarah Chen]: text...` plain text → passes through existing `summarize-session.ts` unchanged. Same AI summary, same action items, same embeddings.
-- **Raw audio cleanup:** Delete `recall_sessions.raw_recording_url` audio after Gladia completes (privacy + storage cost). Keep diarized transcript indefinitely.
-- **Failure recovery:** Gladia fails 3 times → `recall_sessions.status = 'transcription_failed'` → toast + email + manual upload fallback. **No retry button** — one-shot fallback. Revisit post-PMF if retry success rate data warrants.
-- **Re-summarization UX:** ASYNC with toast. Coach clicks "Confirm speakers" → optimistic UI update (labels change immediately) → toast: "Regenerating summary…" → Supabase Realtime delivers updated summary → success toast. Coach can navigate away mid-regen.
-- **Recall recording deletion:** Try Recall DELETE endpoint first (verify exists at impl). Fallback: rely on Recall 7d GC + disclose in privacy policy ("Raw audio retained up to 7 days for processing, then permanently deleted").
-- **Webhook signature header:** verify exact field name (`x-gladia-signature` is best guess) from Gladia docs as first impl step. Not a product decision.
+- **Streaming vs. Gladia (amended):** 6.2b's Recall streaming transcript is the **live, in-meeting** view. Once the recording is ready post-meeting, Gladia re-transcribes it for the **final, high-quality diarized** transcript, which **overwrites** `sessions.transcript_text`. Streaming gives immediacy; Gladia gives quality.
+- **No double summary (amended):** `finalizeStreamingTranscript` (runs on `bot.call_ended`) **no longer eagerly summarizes bot sessions** — it only concatenates chunks into `transcript_text`. The summary is generated once, by the Gladia path, on the diarized transcript. Avoids ~$50–125/mo wasted AI spend and a confusing summary-then-changes UX.
+- **Diarization config:** `min_speakers=2`, `max_speakers=4`.
+- **Async pattern:** Gladia webhook callback. Fallback polling deferred until webhooks prove unreliable.
+- **Speaker mapping defaults:** Speaker 0 → `"Coach"`, Speaker 1 → matched `clients.name`. Stored in `recall_sessions.speaker_map` JSONB. Coach can manually reassign.
+- **Multi-speaker flag:** >2 distinct speakers → `speaker_review_needed = true` → dashboard banner.
+- **Failure recovery (amended):** Gladia submit 5xx → exponential backoff, 3 attempts. If submission ultimately fails OR Gladia returns `status:'error'` → **fall back to summarizing the existing streaming `transcript_text`** (`runSummarize` on it) → `recall_sessions.status='done'`. Only if no streaming transcript exists → `status='transcription_failed'` → toast + email + manual-upload fallback. No retry button.
+- **Source field:** new `sessions.source` column: `"recall_ai"` (bot) | `"manual"` (upload).
+- **Raw audio cleanup (amended, locked 2026-05-17):** Do **not** call a Recall DELETE endpoint and do **not** copy audio to our storage (no extra cost). Rely on Recall's 7-day GC — playback works for 7 days post-meeting, then auto-purged. Null out `recall_sessions.raw_recording_url` (stale signed URL) after Gladia completes — harmless, playback uses `sessions.transcript_audio_url` + `recording_id`. Privacy policy: "Raw audio retained up to 7 days for processing and playback, then permanently deleted."
+- **Re-summarization UX:** ASYNC with toast. "Confirm speakers" → optimistic label update → toast "Regenerating summary…" → Supabase Realtime delivers updated summary → success toast.
+- **Webhook signature header:** verify exact field name (`x-gladia-signature` is best guess) from Gladia docs as first impl step.
 
 ## Story
 
 **As a** system,
-**I need** to transcribe Recall.ai bot-captured audio via Gladia, map speakers to coach/client, and feed it into the existing AI summary pipeline,
-**so that** auto-transcribed sessions are indistinguishable from manual uploads once processed — same summary quality, same action item extraction, same Solis retrievability.
+**I need** to re-transcribe Recall.ai bot recordings via Gladia with speaker diarization, map speakers to coach/client, and regenerate the AI summary from the diarized transcript,
+**so that** auto-transcribed sessions reach manual-upload quality — accurate speaker labels, same summary quality, same action-item extraction, same Solis retrievability.
 
 ## Context
 
-**Already shipped:**
-- `recall_sessions` table with `raw_recording_url` populated by Story 6.2 webhook on `bot.call_ended`.
-- `summarize-session.ts` at `apps/web/src/lib/sessions/summarize-session.ts` (Epic 3) — takes speaker-labeled plain text, generates AI summary + action items + embeddings.
-- `sessions` table with title, summary, action_items, embedding columns.
-- `deepgram-service.ts` at `apps/web/src/lib/services/transcription/` — handles manual uploads.
-- Solis hybrid RAG (Story 4.1) — uses `sessions.embedding` for retrieval.
-- Client Card AI Intelligence Strip (Story 7.2 — not yet built, but `summarize-session.ts` is the integration point).
+**Already shipped (verified against codebase 2026-05-17):**
+- `recall_sessions` table (migration 025). `raw_recording_url` is populated on the **`recording.done`** webhook event (`apps/web/src/app/api/recall/webhook/route.ts`), after fetching the recording from Recall's API.
+- **Story 6.2b live streaming:** during a bot meeting, transcript chunks stream into `sessions.transcript_chunks` (migration 026). `ensureSessionRow` lazy-creates the `sessions` row on `bot.in_call_recording`. On `bot.call_ended`, `finalizeStreamingTranscript` concatenates chunks → `sessions.transcript_text`. So **a `sessions` row already exists** for every bot meeting, linked via `sessions.recall_session_id` (UNIQUE).
+- `runSummarize(sessionId, userId)` — `apps/web/src/lib/sessions/summarize-session.ts`. Reads `transcript_text` off an existing session, generates summary + key_topics + embedding + title. Does **not** create rows or generate action items.
+- `maybeAutoGenerateActionItems(sessionId, userId, supabase)` — `apps/web/src/lib/sessions/generate-action-items.ts` (Story 6.2c).
+- **Story 6.2c audio playback:** `sessions.transcript_audio_url` + `recall_sessions.recording_id` power recording playback in the session detail view.
+- `deepgram-transcription-service.ts` — `apps/web/src/lib/services/transcription/` — manual uploads.
+- Config: `apps/web/src/lib/config/env.ts` (import `{ config }` from `@/lib/config/env`).
+- Session detail view: `apps/web/src/app/(dashboard)/clients/[id]/sessions/[sessionId]/page.tsx`.
 
 **What's new:**
-- Gladia API client + webhook callback handler.
-- Speaker mapping logic (`map-speakers.ts`).
-- Extension of `recall_sessions` table: `diarized_transcript`, `speaker_map`, `speaker_review_needed`.
+- Gladia API client (`gladia-service.ts`) + webhook callback handler.
+- Speaker mapping logic (`map-speakers.ts`) + transcript formatter (`format-diarized-transcript.ts`).
+- Bridge from Gladia output into the existing summary pipeline (`process-recall-transcript.ts`).
+- `recall_sessions` columns: `gladia_job_id`, `diarized_transcript`, `speaker_map`, `speaker_review_needed`.
 - New `sessions.source` column.
-- Manual speaker reassignment UI in session detail view.
+- Manual speaker reassignment UI in the session detail view.
+- Modify `finalize-streaming.ts` to skip eager summary for bot sessions.
 
 ## Acceptance Criteria
 
-### Gladia Submission (triggered by Story 6.2 webhook)
-- [ ] After Story 6.2 webhook handler processes `bot.call_ended` → fire-and-forget POST to `/api/gladia/transcribe` with `{ recall_session_id }`.
-- [ ] Route handler in `apps/web/src/app/api/gladia/transcribe/route.ts`:
-  - Fetch `recall_sessions` row by ID.
-  - Submit to Gladia: `POST https://api.gladia.io/v2/pre-recorded` with body:
+### Gladia Job Submission (triggered from `recording.done` webhook)
+- [ ] In `apps/web/src/app/api/recall/webhook/route.ts`, `case 'recording.done'`: after `raw_recording_url` is set on `recall_sessions`, `await submitGladiaJob(recallSession.id, supabase)`. **Replace** the legacy `processRecallRecording` else-branch — that path runs Deepgram and would produce a conflicting session. Keep the `transcript_audio_url` attach (6.2c playback). If no `sessions` row exists yet (missed streaming), call `ensureSessionRow` first.
+- [ ] `gladia-service.ts` `submitGladiaJob(recallSessionId, supabase)`:
+  - Fetch `recall_sessions` row. If no `raw_recording_url` → log + return.
+  - **Idempotency:** if `gladia_job_id` already set → skip (handles webhook duplicates).
+  - Submit `POST https://api.gladia.io/v2/pre-recorded`:
     ```json
     {
       "audio_url": "<raw_recording_url>",
       "diarization": true,
-      "diarization_config": {
-        "min_speakers": 2,
-        "max_speakers": 4
-      },
-      "callback_url": "https://meetsolis.com/api/gladia/webhook"
+      "diarization_config": { "min_speakers": 2, "max_speakers": 4 },
+      "callback_url": "<config.app.url>/api/gladia/webhook"
     }
     ```
-  - Auth: `x-gladia-key: ${GLADIA_API_KEY}` header.
-  - Store Gladia job ID in `recall_sessions.gladia_job_id`.
-  - Update `recall_sessions.status = 'transcribing'`.
-- [ ] **Retry logic:** if Gladia returns 5xx → exponential backoff (1s, 4s, 16s) up to 3 attempts. After 3 failures → status = `transcription_failed`.
-- [ ] **Idempotency:** if `recall_sessions.gladia_job_id` already set, skip resubmission (handles webhook duplicates from Story 6.2).
+  - Auth header: `x-gladia-key: <config.gladia.apiKey>`.
+  - Store returned job id in `recall_sessions.gladia_job_id`; set `status = 'transcribing'`.
+  - **Retry:** 5xx → exponential backoff (1s, 4s, 16s), 3 attempts. After 3 failures → invoke the failure-recovery fallback (see below).
+  - **Mock mode:** when `config.useMockServices` is true OR `config.gladia.apiKey` is unset → skip the real API call, return a canned job id, and have the webhook handler process a fixture instead. Avoids API cost in dev/test.
 
-### Gladia Webhook Callback
-- [ ] **Webhook endpoint** `POST /api/gladia/webhook`:
-  - Verify HMAC signature header `x-gladia-signature` against `GLADIA_WEBHOOK_SECRET`. Reject mismatches with 401.
-  - Payload: `{ id: string (job_id), status: 'done' | 'error', result: { transcription: { utterances: [...] }, ... } }`.
-  - Look up `recall_sessions` by `gladia_job_id`. If not found, log + 200.
+### Gladia Webhook Callback — `POST /api/gladia/webhook`
+- [ ] Verify HMAC signature header (`x-gladia-signature` — confirm exact name in Gladia docs as first impl step) against `config.gladia.webhookSecret`. Reject mismatch with 401.
+- [ ] Zod-validate payload: `{ id: string, status: 'done' | 'error', result?: {...} }`.
+- [ ] Look up `recall_sessions` by `gladia_job_id`. Not found → log + return 200.
+- [ ] Return 200 within 5s; heavy work is awaited but lightweight (parse + DB writes + one AI summary chain — matches the existing `recall/webhook` pattern which awaits `finalizeStreamingTranscript`).
 - [ ] **On `status: 'done'`:**
-  - Parse `result.transcription.utterances` (Gladia format: `[{ speaker: int, text: string, start: float, end: float }]`).
-  - Store as JSONB in `recall_sessions.diarized_transcript`.
-  - Run speaker mapping (next section).
-  - Trigger pipeline integration (next section).
-  - Update `recall_sessions.status = 'done'`.
-  - Delete raw audio: call `DELETE /api/recall/recordings/{recall_bot_id}` (Recall.ai endpoint) → log success/failure but don't block.
-  - Clear `recall_sessions.raw_recording_url` (null it out).
-- [ ] **On `status: 'error'`:**
-  - Update `recall_sessions.status = 'transcription_failed'` + `error_reason`.
-  - Fire toast + Resend email (same fallback as Story 6.2).
-- [ ] Webhook returns 200 within 5s. Heavy work async.
+  - Parse `result.transcription.utterances` (`[{ speaker: int, text: string, start: float, end: float }]`).
+  - Store raw utterances JSONB → `recall_sessions.diarized_transcript`.
+  - Run speaker mapping → store `speaker_map` + `speaker_review_needed`.
+  - Run pipeline integration (below).
+  - `recall_sessions.status = 'done'`; null `raw_recording_url`.
+- [ ] **On `status: 'error'`:** run failure-recovery fallback (below).
 
-### Speaker ID Mapping
-- [ ] In `apps/web/src/lib/sessions/map-speakers.ts`:
-  - Input: Gladia utterances + `recall_sessions.client_id`.
-  - Lookup client name: `clients.name` from `client_id`.
-  - Count distinct speakers in utterances.
-  - **Case A (exactly 2 speakers):**
-    - `speaker_0` → `"Coach"`
-    - `speaker_1` → `<client_name>`
-    - `speaker_review_needed = false`
-  - **Case B (>2 speakers):**
-    - `speaker_0` → `"Coach"`
-    - `speaker_1` → `<client_name>`
-    - `speaker_2`, `speaker_3` → `"Unknown 1"`, `"Unknown 2"`
-    - `speaker_review_needed = true`
-  - **Case C (1 speaker — rare, suggests recording failure):**
-    - `speaker_0` → `"Coach"` (best guess)
-    - `speaker_review_needed = true`
-    - Add note in dashboard banner: "Only one voice detected — verify recording quality"
-  - Store map as JSONB in `recall_sessions.speaker_map`: `{ "speaker_0": "Coach", "speaker_1": "Sarah Chen" }`.
+### Speaker ID Mapping — `apps/web/src/lib/sessions/map-speakers.ts`
+- [ ] Input: Gladia utterances + `recall_sessions.client_id`. Look up `clients.name`. Count distinct speakers.
+  - **Case A (exactly 2):** `speaker_0`→`"Coach"`, `speaker_1`→`<client_name>`, `speaker_review_needed = false`.
+  - **Case B (>2):** `speaker_0`→`"Coach"`, `speaker_1`→`<client_name>`, `speaker_2/3`→`"Unknown 1"/"Unknown 2"`, `speaker_review_needed = true`.
+  - **Case C (1):** `speaker_0`→`"Coach"`, `speaker_review_needed = true`, dashboard note: "Only one voice detected — verify recording quality".
+- [ ] Store as JSONB `recall_sessions.speaker_map`: `{ "speaker_0": "Coach", "speaker_1": "Sarah Chen" }`.
 
-### Pipeline Integration (feeds existing AI summary)
-- [ ] In `apps/web/src/lib/sessions/process-recall-transcript.ts`:
-  - Format diarized + mapped transcript as plain text:
+### Pipeline Integration — `apps/web/src/lib/sessions/process-recall-transcript.ts`
+- [ ] `processRecallTranscript(recallSessionId, supabase)`:
+  - Load `recall_sessions` (has `diarized_transcript`, `speaker_map`, `client_id`, `user_id`).
+  - Find the existing `sessions` row: `sessions` where `recall_session_id = recallSessionId`. If missing → `ensureSessionRow(recallSessionId, supabase)`.
+  - Format diarized + mapped utterances → plain text via `format-diarized-transcript.ts`:
     ```
     [Coach]: Welcome back, Sarah. How did the week go?
     [Sarah Chen]: Honestly, a lot better than I expected...
-    [Coach]: Walk me through what shifted.
     ```
-  - Call existing `summarize-session.ts` with this text + `{ client_id, user_id, source: 'recall_ai' }`.
-  - `summarize-session.ts` creates `sessions` row with:
-    - `transcript` = plain text
-    - `summary`, `action_items`, `embedding`, `title` = AI-generated (existing pipeline)
-    - `source = 'recall_ai'`
-    - `recall_session_id` (FK back to `recall_sessions`) — new column
-  - On success: update `recall_sessions.session_id` (FK to new session).
-  - On AI summary failure: log + update `recall_sessions.status = 'summary_failed'` → coach can manually retry from dashboard.
+  - **Update** the existing `sessions` row: `transcript_text` = formatted diarized text (overwrites the streaming transcript), `source = 'recall_ai'`.
+  - `await runSummarize(sessionId, userId)` — existing signature; it reads `transcript_text` and updates `summary`, `key_topics`, `embedding`, `title`.
+  - If `runSummarize` returns `'complete'` → `await maybeAutoGenerateActionItems(sessionId, userId, supabase)`.
+  - If it returns `'error'` → set `recall_sessions.status = 'summary_failed'` (coach can retry from dashboard).
+- [ ] Do **not** create a new `sessions` row and do **not** pass text/`source` into `runSummarize`.
+
+### `finalize-streaming.ts` Change (no double summary)
+- [ ] In `apps/web/src/lib/services/recall/finalize-streaming.ts`: remove the eager `runSummarize` + `maybeAutoGenerateActionItems` chain. Keep: concatenate `transcript_chunks` → `transcript_text`, set `transcript_streaming_complete = true`. The summary is produced once, by the Gladia path.
+- [ ] Between `bot.call_ended` and Gladia completion the session has a transcript but no summary — the session detail view shows a "Generating summary…" state. Verify the existing processing/empty state covers this; add one if not.
+
+### Failure Recovery Fallback
+- [ ] Shared helper invoked when Gladia submission fails 3× OR webhook returns `status:'error'`:
+  - If the `sessions` row has a non-empty streaming `transcript_text` → `runSummarize` + `maybeAutoGenerateActionItems` on it; set `recall_sessions.status = 'done'` (degraded diarization — acceptable, coach still gets a summary). Log the degradation.
+  - Else (no streaming transcript) → `recall_sessions.status = 'transcription_failed'` + `error_reason`; fire toast + Resend email (same fallback channel as Story 6.2); coach uses manual upload.
 
 ### Manual Speaker Reassignment UI
-- [ ] **Session detail view** (`apps/web/src/app/(dashboard)/sessions/[id]/page.tsx` — verify path, may be embedded in client detail):
-  - If `sessions.source = 'recall_ai'` AND `recall_sessions.speaker_review_needed = true` → show yellow banner at top: "Multiple speakers detected. Please verify the speaker labels below."
-  - **Speaker label dropdown** above each speaker section in transcript view:
-    - Options: "Coach", `<client_name>`, "Unknown 1", "Unknown 2", "Custom…" (free text input)
-    - Default = current `speaker_map` value
-    - Change a dropdown → mark form as dirty
-- [ ] **"Confirm speakers" button** appears when form is dirty:
-  - Click → `PATCH /api/recall/sessions/{id}/speakers` with new map
-  - Updates `recall_sessions.speaker_map` + sets `speaker_review_needed = false`
-  - Re-runs `summarize-session.ts` with corrected speaker labels → updates `sessions.summary`, `action_items`, `embedding`
-  - Toast: "Speakers updated. Summary regenerated."
-- [ ] **Auto-confirm path:** if 2 speakers detected (no review needed), button is hidden — coach can still edit but no banner pressure.
+- [ ] **Session detail view** (`apps/web/src/app/(dashboard)/clients/[id]/sessions/[sessionId]/page.tsx`):
+  - If `sessions.source = 'recall_ai'` AND `recall_sessions.speaker_review_needed = true` → `SpeakerReviewBanner` (yellow): "Multiple speakers detected. Please verify the speaker labels below."
+  - `SpeakerMappingEditor` — dropdown per speaker label: options `"Coach"`, `<client_name>`, `"Unknown 1"`, `"Unknown 2"`, `"Custom…"` (free text). Default = current `speaker_map`. Editing marks the form dirty.
+- [ ] **"Confirm speakers" button** (visible when dirty):
+  - `PATCH /api/recall/sessions/[id]/speakers` where `[id]` = `sessions.id`. Clerk-authenticated. Zod-validate `{ speaker_map: Record<string,string> }`.
+  - Handler: load session → `recall_session_id` → update `recall_sessions.speaker_map` + `speaker_review_needed = false`; reformat `transcript_text` from `diarized_transcript` + new map; update `sessions.transcript_text`; kick off `runSummarize` + `maybeAutoGenerateActionItems` **async**; respond 200 immediately.
+  - UI: optimistic label update → toast "Regenerating summary…" → Supabase Realtime delivers updated summary → success toast. Coach can navigate away mid-regen.
+- [ ] If 2 speakers detected (no review needed): no banner, button hidden until the coach edits.
 
-### Transcription Provider Routing
-- [ ] **Env var:** `TRANSCRIPTION_PROVIDER` = `deepgram` | `gladia` | `mock`. Defaults to `deepgram`. Acts as SYSTEM override for dev/staging.
-- [ ] **In `summarize-session.ts` (manual upload path):**
-  - If `TRANSCRIPTION_PROVIDER` env is set → use it (system override).
-  - Else → read `user_preferences.manual_transcription_provider` (added in Story 6.5, defaults to `deepgram` until then).
-- [ ] **Bot session path (this story):** always Gladia, regardless of env or user preference. Hardcoded — bot quality warrants Gladia cost.
-- [ ] **Mock provider:** for local dev — reads a fixture file, returns canned diarized output. Avoids API costs during testing.
+### Transcription Provider Routing (6.3 scope only)
+- [ ] Extend the `TRANSCRIPTION_PROVIDER` env enum in `config/env.ts` to add `'gladia'` (current: `placeholder | deepgram | openai-whisper`). Documents the value for Story 6.5; **bot sessions ignore it** — bot path is hardcoded to Gladia.
+- [ ] Manual-upload provider preference (Deepgram vs Gladia) is **out of scope** — Story 6.5.
 
 ### Quality / Standards
 - [ ] All files ≤500 lines.
-- [ ] No `process.env.*` direct access — extend `apps/web/src/lib/config.ts` with `gladia: { apiKey, webhookSecret, baseUrl }`.
-- [ ] Zod validates Gladia webhook payload + speaker reassignment request body.
-- [ ] No `any` — Gladia response types in `packages/shared/src/types/gladia.ts`.
-- [ ] All API routes use standard error handler.
-- [ ] Server-only logic; speaker reassignment dropdown is `"use client"`.
+- [ ] No `process.env.*` direct access — extend `config/env.ts`: `envSchema` gets `GLADIA_API_KEY`, `GLADIA_WEBHOOK_SECRET` (both `.optional()`); `config` gets `gladia: { apiKey, webhookSecret, baseUrl: 'https://api.gladia.io/v2' }`.
+- [ ] Zod validates the Gladia webhook payload + the speaker reassignment request body.
+- [ ] No `any` — Gladia types in `packages/shared/src/types/gladia.ts` (`DiarizedUtterance`, `SpeakerMap`); extend `Session` (`source`) and `RecallSession` (new columns).
+- [ ] All API routes use the standard error handler.
+- [ ] `SpeakerMappingEditor` / `SpeakerReviewBanner` are `"use client"`; all transcription/pipeline logic is server-only.
 - [ ] Tests:
-  - Unit: speaker mapping logic — 1 speaker, 2 speakers, 3+ speakers cases.
+  - Unit: speaker mapping — 1, 2, 3+ speaker cases.
   - Unit: HMAC signature verification.
-  - Unit: transcript formatter — produces `[Speaker]: text` format correctly.
-  - Integration: webhook handler updates DB state + triggers pipeline.
-  - Integration: speaker reassignment re-runs summary.
-- [ ] **Privacy:** raw audio deleted within 24h of transcription complete. Log retention policy applied.
+  - Unit: transcript formatter — produces `[Speaker]: text`, groups consecutive same-speaker utterances.
+  - Unit: failure-recovery fallback — with vs. without a streaming transcript.
+  - Integration: webhook `done` → updates `sessions` row + runs summary (no new row created).
+  - Integration: speaker reassignment re-runs summary on the corrected transcript.
+- [ ] **Privacy:** raw audio is purged by Recall's 7-day GC; `recall_sessions.raw_recording_url` nulled after Gladia completes.
 
 ## Technical Notes
 
 ### Recommended File Layout
 ```
 apps/web/src/app/api/gladia/
-  transcribe/route.ts          # POST — submit job
-  webhook/route.ts             # POST — receive completion
+  webhook/route.ts             # POST — receive Gladia completion (external callback)
 
 apps/web/src/app/api/recall/sessions/[id]/
   speakers/route.ts            # PATCH — update speaker map + re-summarize
 
 apps/web/src/lib/services/transcription/
-  gladia-service.ts            # API client + retry logic
+  gladia-service.ts            # API client, submitGladiaJob, retry, mock mode
   verify-gladia-signature.ts   # HMAC verification
 
 apps/web/src/lib/sessions/
   map-speakers.ts              # speaker_0 → "Coach" logic
-  process-recall-transcript.ts # bridges Gladia output → summarize-session
-  format-diarized-transcript.ts # JSONB → plain text formatter
+  process-recall-transcript.ts # bridges Gladia output → existing session + runSummarize
+  format-diarized-transcript.ts # utterances + map → plain text
 
 apps/web/src/components/sessions/
-  SpeakerMappingEditor.tsx     # dropdown + confirm button UI
-  SpeakerReviewBanner.tsx      # yellow banner for review-needed state
+  SpeakerMappingEditor.tsx     # dropdown + confirm button
+  SpeakerReviewBanner.tsx      # yellow review-needed banner
+```
+Modified: `apps/web/src/app/api/recall/webhook/route.ts` (`recording.done` branch), `apps/web/src/lib/services/recall/finalize-streaming.ts`, `apps/web/src/lib/config/env.ts`.
+There is **no** `/api/gladia/transcribe` route — the webhook calls `submitGladiaJob()` directly (matches the `finalizeStreamingTranscript` / `processRecallRecording` precedent and avoids an unauthenticated route).
+
+### DB Migration — `apps/web/migrations/028_gladia_transcription.sql`
+```sql
+-- Migration 028: Gladia Transcription Pipeline (Story 6.3)
+
+ALTER TABLE recall_sessions
+  ADD COLUMN IF NOT EXISTS gladia_job_id TEXT UNIQUE,
+  ADD COLUMN IF NOT EXISTS diarized_transcript JSONB,
+  ADD COLUMN IF NOT EXISTS speaker_map JSONB,
+  ADD COLUMN IF NOT EXISTS speaker_review_needed BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE recall_sessions DROP CONSTRAINT IF EXISTS recall_sessions_status_check;
+ALTER TABLE recall_sessions ADD CONSTRAINT recall_sessions_status_check
+  CHECK (status IN ('pending','joining','in_meeting','transcribing','done','error',
+                    'quota_exceeded','skipped','transcription_failed','summary_failed'));
+
+-- sessions.recall_session_id already exists (migration 026) — do NOT re-add.
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'manual'
+    CHECK (source IN ('manual','recall_ai'));
 ```
 
 ### Gladia API Reference
-- Base URL: `https://api.gladia.io/v2`
-- Auth: `x-gladia-key: <API_KEY>` header
-- Submit job: `POST /pre-recorded` — returns `{ id, result_url }`
-- Webhook payload includes `result.transcription.utterances` (diarization output)
-- Webhook signature: HMAC SHA-256 via `x-gladia-signature` header (confirm exact name during impl — Gladia docs)
-
-### DB Migration
-```sql
--- extend recall_sessions
-ALTER TABLE recall_sessions
-  ADD COLUMN IF NOT EXISTS gladia_job_id text UNIQUE,
-  ADD COLUMN IF NOT EXISTS diarized_transcript jsonb,
-  ADD COLUMN IF NOT EXISTS speaker_map jsonb,
-  ADD COLUMN IF NOT EXISTS speaker_review_needed boolean NOT NULL DEFAULT false,
-  ADD COLUMN IF NOT EXISTS session_id uuid REFERENCES sessions(id) ON DELETE SET NULL;
-
--- update status enum to allow new states
-ALTER TABLE recall_sessions DROP CONSTRAINT IF EXISTS recall_sessions_status_check;
-ALTER TABLE recall_sessions ADD CONSTRAINT recall_sessions_status_check
-  CHECK (status IN ('pending','joining','in_meeting','transcribing','done','error','quota_exceeded','skipped','transcription_failed','summary_failed'));
-
--- sessions.source
-ALTER TABLE sessions
-  ADD COLUMN IF NOT EXISTS source text NOT NULL DEFAULT 'manual'
-    CHECK (source IN ('manual','recall_ai')),
-  ADD COLUMN IF NOT EXISTS recall_session_id uuid REFERENCES recall_sessions(id) ON DELETE SET NULL;
-```
-
-Update `packages/shared/src/types/` — add `DiarizedUtterance`, `SpeakerMap`, extend `Session`, `RecallSession`.
+- Base URL `https://api.gladia.io/v2`. Auth header `x-gladia-key`.
+- Submit: `POST /pre-recorded` → `{ id, result_url }`.
+- Webhook payload carries `result.transcription.utterances`.
+- Signature: HMAC SHA-256, header name to confirm in Gladia docs (first impl step).
 
 ### Gladia Cost Reference
-- ~$0.61–0.75/hr per session
-- 25 sessions/coach/mo × ~1 hr avg × $0.70 = ~$17.50/coach/mo COGS just for transcription
-- 100 paying coaches → ~$1,750/mo Gladia cost (on top of Recall ~$1,250)
-- Total COGS ~$30/coach/mo at full Pro usage — comfortable at $99/mo price
+- ~$0.61–0.75/hr per session. 25 sessions/coach/mo × ~1 hr × $0.70 ≈ $17.50/coach/mo.
+- 100 paying coaches ≈ $1,750/mo Gladia + ~$1,250/mo Recall. Total COGS ~$30/coach/mo — comfortable at $99/mo.
 
 ### New Env Vars
-- `GLADIA_API_KEY` — production API token.
-- `GLADIA_WEBHOOK_SECRET` — HMAC signing secret.
-- `TRANSCRIPTION_PROVIDER` — already exists for Deepgram; document new `gladia` + `mock` values.
-
-Add to `.env.example` with placeholders.
-
-### Raw Audio Cleanup
-- Recall.ai stores recordings for 7 days by default (verify in their dashboard).
-- We delete on our trigger after Gladia completes via Recall's DELETE endpoint.
-- Failure to delete is logged but non-blocking — Recall will GC after 7d regardless.
-- No long-term storage of raw audio on our side. Diarized transcript (text) is what we retain.
+- `GLADIA_API_KEY`, `GLADIA_WEBHOOK_SECRET` — add to `.env.example` with placeholders.
+- `TRANSCRIPTION_PROVIDER` — document new `gladia` value.
 
 ## Operator Notes (manual setup before deploy)
 
-1. **Gladia account:**
-   - Sign up at gladia.io → request production access.
-   - Confirm HIPAA/SOC2 BAA — required if any US healthcare clients (defer formal BAA execution until coach asks).
-   - Generate API key + webhook secret → set in Vercel env.
-   - Configure webhook URL in Gladia dashboard: `https://meetsolis.com/api/gladia/webhook` (prod) + dev tunnel for local.
-2. **Recall.ai recording deletion:**
-   - Confirm DELETE endpoint exists in Recall API. If not, rely on Recall's 7-day GC.
-3. **Test transcript:** drop a 10-min sample audio (coach + client style) → run end-to-end → verify diarization quality is acceptable. If diarization fails on real coaching audio, document and consider AssemblyAI as fallback.
-4. **PROMPT GATE (BRAINSTORM §9):** This story doesn't add new prompts — uses existing `summarize-session.ts`. No prompt gate trigger here.
+1. **Gladia account:** sign up → request production access → confirm HIPAA/SOC2 BAA (defer formal execution until a coach asks) → generate API key + webhook secret → set in Vercel env → configure webhook URL `https://meetsolis.com/api/gladia/webhook` (+ dev tunnel for local).
+2. **Test transcript:** run a 10-min coach+client sample end-to-end → verify diarization quality. If it fails on real coaching audio, document + consider AssemblyAI fallback.
+3. **PROMPT GATE (BRAINSTORM §9):** no new prompts — uses existing `summarize-session.ts`. No gate trigger.
 
 ## Out of Scope (defer to other stories)
 
 - Coach Brief generation — Story 6.4.
-- User-facing transcription provider preference (Deepgram vs Gladia for manual uploads) — Story 6.5.
-- Polling fallback if Gladia webhooks don't fire — defer; implement only if webhooks prove unreliable.
-- Real-time live transcript during meeting — Story 6.5 (Recall provides separate streaming endpoint).
-- Multi-language transcription — English only at launch.
-- Custom vocabulary / coaching glossary upload — post-launch.
+- User-facing manual-upload transcription provider preference — Story 6.5.
+- Polling fallback if Gladia webhooks don't fire — defer.
+- Real-time live transcript during meeting — already shipped (Story 6.2b).
+- Multi-language transcription, custom vocabulary — post-launch.
 - AssemblyAI fallback provider — defer unless Gladia diarization quality fails.
 
 ## Estimated Effort
 
-- **1.5 days** (matches PRD epic-6 estimate). Largest chunks: Gladia client + webhook handler (~0.5d), speaker mapping + pipeline integration (~0.5d), speaker reassignment UI + tests (~0.5d).
+- **~1.25 days** (slightly under the original 1.5d — transcript-to-session plumbing and the `sessions` row already exist from 6.2b). Chunks: Gladia client + webhook (~0.5d), speaker mapping + pipeline bridge + finalize-streaming change (~0.4d), speaker reassignment UI + tests (~0.4d).
 
 ## Unresolved Questions
 
-_(All locked 2026-05-11 — see Locked Decisions section. Header name + delete endpoint = impl-time verification, not product decisions.)_
+_All product decisions locked (incl. raw audio retention — no-delete, 7-day GC, no copy-to-storage). Gladia signature header name = impl-time doc check, not a product decision._
+
+## Dev Agent Record
+
+### Agent Model Used
+James (dev) — claude-opus-4-7
+
+### Completion Notes List
+
+- **Bot transcription is a 3-way router, not Gladia-only (post-review change).** `transcribeBotRecording` (in `gladia-service.ts`, renamed from `submitGladiaJob`) routes by config: `USE_MOCK_SERVICES=true` → fixture (dev/test); real services + no `GLADIA_API_KEY` → **Deepgram batch on the real recording**; real services + `GLADIA_API_KEY` set → Gladia. This closed a gap where production-without-a-Gladia-key would have processed the canned fixture. Gladia is now an opt-in quality upgrade — set the env var to activate it, zero code change. MVP can launch on Deepgram (no Gladia account needed). All three providers emit `DiarizedUtterance[]` into the identical `handleGladiaDone` pipeline.
+- **Naming debt accepted:** `handleGladiaDone` and the `recall_sessions.gladia_job_id` column are provider-agnostic in practice (Deepgram/mock paths store synthetic `deepgram-*` / `mock-gladia-*` markers). Not renamed — a column rename = a migration, the function rename touches 5 files for zero behaviour change.
+- **Deepgram fallback is synchronous** (no webhook) — it transcribes inside the `recording.done` handler, so `maxDuration = 300` is set on the recall webhook route. The Gladia path stays async via `/api/gladia/webhook`.
+- **Gladia callback auth — deviation from the literal AC, resolved per the story's own "impl-time doc check".** The story assumed an HMAC-signed `x-gladia-signature` header. Doc research (Gladia v2 OpenAPI spec + API reference) confirmed Gladia does **not** sign per-job `callback_config` callbacks — no signature header exists (only the separate dashboard "Webhooks" feature is Svix-signed, a different mechanism). Implemented the documented mitigation instead: a shared-secret token in the callback URL (`?token=<GLADIA_WEBHOOK_SECRET>`), verified with `timingSafeEqual`. File is `verify-gladia-callback.ts` (not `verify-gladia-signature.ts`). The 401-on-mismatch intent is preserved. The HMAC unit test became a token-verification unit test.
+- **Gladia submit body — `callback_url` is deprecated** in Gladia v2. Used `callback: true` + `callback_config: { url, method: 'POST' }`. Diarization config (`min_speakers`/`max_speakers`) unchanged.
+- **Callback payload shape corrected from research.** Gladia v2 callback is `{ id, event: 'transcription.success' | 'transcription.error', payload }`, not `{ id, status, result }`. Utterances live at `payload.transcription.utterances`; `speaker` is optional per the OpenAPI spec, so the Zod schema defaults it to `0`.
+- **Re-summarization UX uses react-query polling, not Supabase Realtime.** The codebase has no Supabase Realtime client usage (Story 6.2b live transcript polls). Followed the established pattern — the session detail page polls `/api/sessions/[id]` every 4s while a bot summary is pending, and toasts once it lands. Same user-facing behavior (optimistic labels → "regenerating" toast → updated summary → success toast).
+- **Failure-recovery email** sent via the existing nodemailer transporter (`mail.ts` → `sendTranscriptionFailedEmail`); the repo has no Resend integration. The "toast" half of the AC is realized as the persistent failure messaging on the session detail page (a webhook cannot fire a client toast).
+- **`process-recording.ts` is now orphaned** — the legacy Deepgram bot path it contained was replaced by Gladia in the `recording.done` branch. Left in place (no longer imported) to keep the change surface minimal; safe to delete in a follow-up.
+- **Mock mode**: `submitGladiaJob` skips the real API when `USE_MOCK_SERVICES` is true or `GLADIA_API_KEY` is unset, and runs `gladia-fixture.ts` through `handleGladiaDone` so dev/test exercises the full pipeline end-to-end.
+- Validation: 27 new tests pass (5 suites); `tsc --noEmit` clean; `next lint` clean (only pre-existing warnings). Pre-existing unrelated failure: `tests/components/sessions/SessionTimeline.test.tsx` references a non-existent `@/components/ui/skeleton` mock — not touched by this story.
+- Migration 028 not yet applied to Supabase — operator must run it before deploy.
+
+### File List
+
+**New:**
+- `apps/web/migrations/028_gladia_transcription.sql`
+- `packages/shared/src/types/gladia.ts`
+- `apps/web/src/lib/services/transcription/gladia-service.ts` — `transcribeBotRecording` 3-way router + Gladia client
+- `apps/web/src/lib/services/transcription/deepgram-batch.ts` — Deepgram diarized fallback
+- `apps/web/src/lib/services/transcription/gladia-fixture.ts`
+- `apps/web/src/lib/services/transcription/verify-gladia-callback.ts`
+- `apps/web/src/lib/sessions/map-speakers.ts`
+- `apps/web/src/lib/sessions/format-diarized-transcript.ts`
+- `apps/web/src/lib/sessions/process-recall-transcript.ts`
+- `apps/web/src/app/api/gladia/webhook/route.ts`
+- `apps/web/src/app/api/recall/sessions/[id]/speakers/route.ts`
+- `apps/web/src/components/sessions/SpeakerReviewBanner.tsx`
+- `apps/web/src/components/sessions/SpeakerMappingEditor.tsx`
+- `apps/web/src/lib/sessions/__tests__/map-speakers.test.ts`
+- `apps/web/src/lib/sessions/__tests__/format-diarized-transcript.test.ts`
+- `apps/web/src/lib/sessions/__tests__/process-recall-transcript.test.ts`
+- `apps/web/src/lib/services/transcription/__tests__/verify-gladia-callback.test.ts`
+- `apps/web/src/lib/services/transcription/__tests__/deepgram-batch.test.ts`
+- `apps/web/src/lib/services/transcription/__tests__/gladia-service.test.ts`
+- `apps/web/src/app/api/gladia/webhook/__tests__/route.test.ts`
+
+**Modified:**
+- `apps/web/src/lib/config/env.ts` — `GLADIA_API_KEY`/`GLADIA_WEBHOOK_SECRET`, `config.gladia`, `gladia` in `TRANSCRIPTION_PROVIDER` enum
+- `apps/web/.env.example` — Gladia env vars
+- `apps/web/src/app/api/recall/webhook/route.ts` — `recording.done` branch calls `transcribeBotRecording`; removed legacy `processRecallRecording` path; `maxDuration = 300`
+- `apps/web/src/lib/services/recall/finalize-streaming.ts` — dropped eager summary; signature now `(recallSessionId, supabase)`
+- `apps/web/src/lib/mail.ts` — `sendTranscriptionFailedEmail`
+- `apps/web/src/app/(dashboard)/clients/[id]/sessions/[sessionId]/page.tsx` — summary + speaker UI + "Generating summary…" state
+- `packages/shared/src/index.ts` — export `./types/gladia`
+- `packages/shared/src/types/recall.ts` — `RecallBotStatus` + `RecallSession` extended
+- `packages/shared/src/types/database.ts` — `Session.source`, `Session.recall_session_id`, `SessionSource`
+
+### Change Log
+| Date | Change |
+|------|--------|
+| 2026-05-18 | Story 6.3 implemented — Gladia transcription pipeline, speaker diarization + mapping, re-summarization, speaker reassignment UI. Status → Ready for Review. |
+| 2026-05-18 | Post-review: added Deepgram fallback — bot transcription is a 3-way router (mock / Deepgram / Gladia). Gladia is now opt-in via `GLADIA_API_KEY`; MVP launches on Deepgram. |

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,7 @@ export * from './types/billing';
 export * from './types/calendar';
 export * from './types/recall';
 export * from './types/transcript';
+export * from './types/gladia';
 
 // Constants
 export * from './constants/services';

--- a/packages/shared/src/types/database.ts
+++ b/packages/shared/src/types/database.ts
@@ -404,6 +404,9 @@ export interface FileWithUser extends File {
 
 export type SessionStatus = 'pending' | 'processing' | 'complete' | 'error';
 
+/** Provenance of a session's transcript (Story 6.3). */
+export type SessionSource = 'manual' | 'recall_ai';
+
 export interface Session {
   id: string;
   user_id: string;
@@ -417,6 +420,10 @@ export interface Session {
   key_topics: string[];
   embedding: number[] | null;
   status: SessionStatus;
+  /** Story 6.3 — 'recall_ai' when produced by the bot/Gladia pipeline. */
+  source: SessionSource;
+  /** Story 6.2b — links a bot session to its recall_sessions row. */
+  recall_session_id: string | null;
   created_at: string;
   updated_at: string;
   action_items?: { id: string; status: string }[];

--- a/packages/shared/src/types/gladia.ts
+++ b/packages/shared/src/types/gladia.ts
@@ -1,0 +1,33 @@
+/**
+ * Gladia transcription types (Story 6.3).
+ *
+ * Gladia v2 pre-recorded API returns diarized utterances. We re-transcribe
+ * Recall.ai bot recordings through Gladia for high-quality speaker labels,
+ * then map raw speaker indices to coach/client names.
+ */
+
+/**
+ * One diarized utterance from Gladia — a contiguous span of speech by one
+ * speaker. `speaker` is a 0-based integer index, stable within a transcript.
+ * Stored raw in recall_sessions.diarized_transcript so the transcript can be
+ * re-formatted whenever the coach corrects the speaker map.
+ */
+export interface DiarizedUtterance {
+  speaker: number;
+  text: string;
+  /** Seconds from start of audio. */
+  start: number;
+  end: number;
+}
+
+/**
+ * Maps a Gladia speaker key (`"speaker_0"`, `"speaker_1"`, …) to a display
+ * name (`"Coach"`, the client's name, `"Unknown 1"`, or a coach-entered
+ * custom label). Stored in recall_sessions.speaker_map.
+ */
+export type SpeakerMap = Record<string, string>;
+
+/** Build the speaker_map key for a 0-based Gladia speaker index. */
+export function speakerKey(speakerIndex: number): string {
+  return `speaker_${speakerIndex}`;
+}

--- a/packages/shared/src/types/recall.ts
+++ b/packages/shared/src/types/recall.ts
@@ -3,6 +3,8 @@
  * Hand-rolled from Recall.ai API docs — no official SDK types.
  */
 
+import type { DiarizedUtterance, SpeakerMap } from './gladia';
+
 // ---------------------------------------------------------------------------
 // Bot status (mirrors recall_sessions.status CHECK constraint)
 // ---------------------------------------------------------------------------
@@ -10,10 +12,13 @@ export type RecallBotStatus =
   | 'pending'
   | 'joining'
   | 'in_meeting'
+  | 'transcribing'
   | 'done'
   | 'error'
   | 'quota_exceeded'
-  | 'skipped';
+  | 'skipped'
+  | 'transcription_failed'
+  | 'summary_failed';
 
 // ---------------------------------------------------------------------------
 // DB row
@@ -32,6 +37,11 @@ export interface RecallSession {
   ended_at: string | null;
   created_at: string;
   updated_at: string;
+  // Story 6.3 — Gladia transcription pipeline
+  gladia_job_id: string | null;
+  diarized_transcript: DiarizedUtterance[] | null;
+  speaker_map: SpeakerMap | null;
+  speaker_review_needed: boolean;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Story 6.3 — Gladia Transcription Pipeline + Speaker Diarization

Re-transcribes Recall.ai bot recordings into **diarized** transcripts, maps speakers to coach/client, and regenerates the AI summary from the diarized text so auto-transcribed sessions reach manual-upload quality.

### What it does
- **3-way provider router** (`transcribeBotRecording`) — picked per config, no code change to switch:
  - `USE_MOCK_SERVICES=true` → fixture (dev/test)
  - real services, no `GLADIA_API_KEY` → **Deepgram batch** (current MVP setting)
  - real services, `GLADIA_API_KEY` set → **Gladia**
- All three emit `DiarizedUtterance[]` into one shared pipeline: speaker mapping → diarized transcript → `runSummarize` → action items.
- **Speaker mapping** — speaker_0→Coach, speaker_1→client; >2 or 1 speaker flags `speaker_review_needed`.
- **Speaker reassignment UI** — `SpeakerReviewBanner` + `SpeakerMappingEditor` on the session detail page; `PATCH /api/recall/sessions/[id]/speakers` reformats the transcript and re-summarizes.
- **No double summary** — `finalize-streaming` no longer eagerly summarizes; the summary is produced once, on the diarized transcript.
- **Failure recovery** — Gladia/Deepgram failure → summarize the streaming transcript if present, else `transcription_failed` + coach email.

### Notable decisions / deviations
- **Gladia is opt-in.** MVP launches on Deepgram (no Gladia account needed). Activate later by setting `GLADIA_API_KEY` — see `backlog/gladia-activation.md`.
- **Callback auth** — Gladia does not sign per-job callbacks (confirmed vs v2 docs). Used the documented mitigation: shared-secret token in the callback URL, verified with `timingSafeEqual`, 401 on mismatch.
- `callback_url` is deprecated in Gladia v2 → used `callback` + `callback_config`.

### DB
- Migration `028_gladia_transcription.sql` — **already applied** to Supabase.

### Testing
- 37 new tests (8 suites): speaker mapping, transcript formatter, callback-token verification, failure recovery, webhook dispatch, Deepgram mapping, 3-way router.
- `tsc --noEmit` clean; `next lint` clean for all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)