### PR TITLE
fix(6.3): QA gate fixes + follow-up backlog

### DIFF
--- a/apps/web/src/app/api/recall/sessions/[id]/speakers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/recall/sessions/[id]/speakers/__tests__/route.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Integration tests — /api/recall/sessions/[id]/speakers (Story 6.3)
+ * Focus: PATCH re-runs the summary on the coach-corrected transcript.
+ */
+
+import { PATCH, GET } from '../route';
+import { NextRequest } from 'next/server';
+
+jest.mock('@clerk/nextjs/server', () => ({ auth: jest.fn() }));
+jest.mock('@/lib/helpers/user', () => ({ getInternalUserId: jest.fn() }));
+jest.mock('@/lib/config/env', () => ({
+  config: { supabase: { url: 'x', serviceRoleKey: 'y' } },
+}));
+
+const mockRunSummarize = jest.fn();
+const mockMaybeAuto = jest.fn();
+jest.mock('@/lib/sessions/summarize-session', () => ({
+  runSummarize: (...a: unknown[]) => mockRunSummarize(...a),
+}));
+jest.mock('@/lib/sessions/generate-action-items', () => ({
+  maybeAutoGenerateActionItems: (...a: unknown[]) => mockMaybeAuto(...a),
+}));
+
+/** FIFO Supabase stub — single() pulls per table; update() is recorded. */
+const responses: Record<string, Array<{ data: unknown }>> = {};
+const updates: Array<{ table: string; values: unknown }> = [];
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      const builder: Record<string, unknown> = {
+        select: () => builder,
+        eq: () => builder,
+        single: () =>
+          Promise.resolve(responses[table]?.shift() ?? { data: null }),
+        update: (values: unknown) => {
+          updates.push({ table, values });
+          return { eq: () => Promise.resolve({ error: null }) };
+        },
+      };
+      return builder;
+    },
+  }),
+}));
+
+import { auth } from '@clerk/nextjs/server';
+import { getInternalUserId } from '@/lib/helpers/user';
+
+const mockAuth = auth as jest.MockedFunction<typeof auth>;
+const mockUserId = getInternalUserId as jest.MockedFunction<
+  typeof getInternalUserId
+>;
+
+const VALID_ID = '11111111-1111-1111-1111-111111111111';
+type AuthReturn = Awaited<ReturnType<typeof auth>>;
+
+function patch(id: string, body: unknown) {
+  return PATCH(
+    new NextRequest(`http://localhost/api/recall/sessions/${id}/speakers`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    }),
+    { params: { id } }
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  updates.length = 0;
+  for (const k of Object.keys(responses)) delete responses[k];
+  mockAuth.mockResolvedValue({ userId: 'clerk_1' } as AuthReturn);
+  mockUserId.mockResolvedValue('user_1');
+  mockRunSummarize.mockResolvedValue('complete');
+});
+
+describe('PATCH /api/recall/sessions/[id]/speakers', () => {
+  it('400 on an invalid session id', async () => {
+    const res = await patch('not-a-uuid', { speaker_map: { speaker_0: 'X' } });
+    expect(res.status).toBe(400);
+  });
+
+  it('401 when unauthenticated', async () => {
+    mockAuth.mockResolvedValue({ userId: null } as AuthReturn);
+    const res = await patch(VALID_ID, { speaker_map: { speaker_0: 'X' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('400 when speaker_map is missing/invalid', async () => {
+    const res = await patch(VALID_ID, { wrong: true });
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when the session is not owned by the caller', async () => {
+    responses.sessions = [
+      { data: { user_id: 'other', recall_session_id: 'rs-1' } },
+    ];
+    const res = await patch(VALID_ID, { speaker_map: { speaker_0: 'Coach' } });
+    expect(res.status).toBe(404);
+  });
+
+  it('reformats the transcript and re-runs the summary on success', async () => {
+    responses.sessions = [
+      { data: { user_id: 'user_1', recall_session_id: 'rs-1' } },
+    ];
+    responses.recall_sessions = [
+      {
+        data: {
+          diarized_transcript: [
+            { speaker: 0, text: 'Hello.', start: 0, end: 1 },
+            { speaker: 1, text: 'Hi.', start: 1, end: 2 },
+          ],
+        },
+      },
+    ];
+
+    const res = await patch(VALID_ID, {
+      speaker_map: { speaker_0: 'Coach', speaker_1: 'Sarah Chen' },
+    });
+    expect(res.status).toBe(200);
+
+    // speaker_map persisted + review flag cleared
+    expect(updates).toContainEqual({
+      table: 'recall_sessions',
+      values: {
+        speaker_map: { speaker_0: 'Coach', speaker_1: 'Sarah Chen' },
+        speaker_review_needed: false,
+      },
+    });
+
+    // transcript reformatted with the corrected labels
+    const sessionUpdate = updates.find(u => u.table === 'sessions');
+    const values = sessionUpdate!.values as Record<string, string>;
+    expect(values.transcript_text).toContain('[Coach]: Hello.');
+    expect(values.transcript_text).toContain('[Sarah Chen]: Hi.');
+    expect(values.source).toBe('recall_ai');
+
+    // summary regeneration triggered
+    expect(mockRunSummarize).toHaveBeenCalledWith(VALID_ID, 'user_1');
+  });
+
+  it('409 when the session has no diarized transcript to re-map', async () => {
+    responses.sessions = [
+      { data: { user_id: 'user_1', recall_session_id: 'rs-1' } },
+    ];
+    responses.recall_sessions = [{ data: { diarized_transcript: [] } }];
+
+    const res = await patch(VALID_ID, {
+      speaker_map: { speaker_0: 'Coach' },
+    });
+    expect(res.status).toBe(409);
+    expect(mockRunSummarize).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/recall/sessions/[id]/speakers', () => {
+  it('returns the speaker map + review state for a bot session', async () => {
+    responses.sessions = [
+      {
+        data: {
+          user_id: 'user_1',
+          recall_session_id: 'rs-1',
+          source: 'recall_ai',
+        },
+      },
+    ];
+    responses.recall_sessions = [
+      {
+        data: {
+          speaker_map: { speaker_0: 'Coach' },
+          speaker_review_needed: true,
+          error_reason: '3 speakers detected',
+          client_id: 'c1',
+        },
+      },
+    ];
+    responses.clients = [{ data: { name: 'Sarah Chen' } }];
+
+    const res = await GET(
+      new NextRequest(
+        `http://localhost/api/recall/sessions/${VALID_ID}/speakers`
+      ),
+      { params: { id: VALID_ID } }
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.speaker_review_needed).toBe(true);
+    expect(body.client_name).toBe('Sarah Chen');
+  });
+});

--- a/apps/web/src/app/api/recall/sessions/[id]/speakers/route.ts
+++ b/apps/web/src/app/api/recall/sessions/[id]/speakers/route.ts
@@ -4,8 +4,8 @@
  * GET   — speaker map + review state for the session detail UI (Story 6.3).
  * PATCH — coach-corrected speaker map → reformat transcript + re-summarize.
  *
- * Re-summarization is fire-and-forget: the coach gets an immediate 200 and the
- * updated summary appears on the next poll.
+ * PATCH re-summarizes synchronously (awaited) so the work reliably completes
+ * on Vercel serverless; the UI shows a 'Saving…' state and polls for the result.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -20,6 +20,8 @@ import { runSummarize } from '@/lib/sessions/summarize-session';
 import { maybeAutoGenerateActionItems } from '@/lib/sessions/generate-action-items';
 
 export const runtime = 'nodejs';
+// PATCH awaits the summary + action-item AI chain — give it headroom.
+export const maxDuration = 120;
 
 function getSupabase() {
   return createClient(config.supabase.url!, config.supabase.serviceRoleKey!);
@@ -177,16 +179,18 @@ export async function PATCH(
       })
       .eq('id', params.id);
 
-    // Re-summarize fire-and-forget — the UI polls for the refreshed summary.
-    runSummarize(params.id, userId)
-      .then(status => {
-        if (status === 'complete') {
-          return maybeAutoGenerateActionItems(params.id, userId, supabase);
-        }
-      })
-      .catch(e =>
-        console.error(`[speakers API] re-summarize failed ${params.id}:`, e)
-      );
+    // Re-summarize synchronously. A fire-and-forget call would be unreliable
+    // on Vercel serverless — the function can be frozen once the response is
+    // sent, dropping the regeneration. The UI shows a 'Saving…' state for the
+    // few seconds this takes, then polls for the refreshed summary.
+    try {
+      const status = await runSummarize(params.id, userId);
+      if (status === 'complete') {
+        await maybeAutoGenerateActionItems(params.id, userId, supabase);
+      }
+    } catch (e) {
+      console.error(`[speakers API] re-summarize failed ${params.id}:`, e);
+    }
 
     return NextResponse.json({ ok: true, speaker_map: speakerMap });
   } catch (error) {

--- a/backlog/6.3-qa-followups.md
+++ b/backlog/6.3-qa-followups.md
@@ -1,0 +1,51 @@
+# Story 6.3 — QA Follow-ups (LOW severity)
+
+From the QA review of Story 6.3 (gate PASS 92/100, Quinn, 2026-05-18).
+Full gate: `docs/qa/gates/6.3-gladia-transcription.yml`.
+
+These are **non-blocking** — 6.3 shipped without them. Pick up when convenient.
+
+## QA-6.3-C2 — Empty-transcript bot session polls "Generating summary…" forever
+**Severity:** LOW
+If Gladia/Deepgram returns no utterances, `runSummarize` returns `'skipped'` and
+never sets `sessions.status`, leaving it `'pending'`. `isAwaitingSummary()` on the
+session detail page then returns true indefinitely → 4s polling with no terminal
+state. Rare (empty recording) but unbounded.
+**Fix:** Give the pipeline a terminal signal for the no-content case — set
+`sessions.status` when `runSummarize` skips, or bound `isAwaitingSummary` by
+`transcript_streaming_complete` / elapsed time.
+**Files:** `apps/web/src/app/(dashboard)/clients/[id]/sessions/[sessionId]/page.tsx`,
+`apps/web/src/lib/sessions/process-recall-transcript.ts`
+
+## QA-6.3-C3 — Gladia webhook unauthenticated if `GLADIA_WEBHOOK_SECRET` unset
+**Severity:** LOW
+`verifyGladiaCallbackToken` returns true when no secret is configured. If an
+operator sets `GLADIA_API_KEY` but forgets `GLADIA_WEBHOOK_SECRET`, the callback
+route accepts unsigned POSTs. Practical risk is low — the handler no-ops unless
+the body carries a real UUID `gladia_job_id` — but it is silent.
+**Fix:** Warn or hard-fail at startup / submit when `GLADIA_API_KEY` is set
+without `GLADIA_WEBHOOK_SECRET`. (Only relevant once Gladia is activated.)
+**Files:** `apps/web/src/lib/services/transcription/gladia-service.ts`,
+`apps/web/src/lib/config/env.ts`
+
+## QA-6.3-C4 — `calendar_events.bot_status` not updated by transcription transitions
+**Severity:** LOW
+The transcription pipeline writes `recall_sessions.status` directly
+(`transcribing` / `done` / `transcription_failed`) and bypasses
+`updateRecallSession`, which is what mirrors status to
+`calendar_events.bot_status`. A `transcription_failed` session still shows
+`done` on the calendar dashboard.
+**Fix:** Mirror terminal transcription status to `calendar_events`, or document
+that `bot_status` reflects only the meeting lifecycle (not transcription).
+**Files:** `apps/web/src/lib/sessions/process-recall-transcript.ts`
+
+## QA-6.3-C5 — Orphaned legacy code + naming debt
+**Severity:** LOW
+`process-recording.ts` is no longer referenced (legacy Deepgram bot path,
+replaced by the 3-way router). `handleGladiaDone` and the
+`recall_sessions.gladia_job_id` column are provider-agnostic in practice (store
+`deepgram-*` / `mock-gladia-*` markers).
+**Fix:** Delete `apps/web/src/lib/services/recall/process-recording.ts` (confirm
+no remaining imports). Optionally rename `handleGladiaDone` →
+`handleDiarizedResult` and the `gladia_job_id` column → `transcription_job_id`
+(a migration) for clarity. Non-urgent.

--- a/docs/qa/gates/6.3-gladia-transcription.yml
+++ b/docs/qa/gates/6.3-gladia-transcription.yml
@@ -1,0 +1,143 @@
+story: "6.3"
+title: "Gladia/Deepgram Bot Transcription + Speaker Diarization"
+reviewer: "Quinn (Test Architect)"
+date: "2026-05-18"
+decision: PASS
+
+quality_score: 92/100
+
+summary: >
+  Strong, well-tested implementation. The post-review pivot to a 3-way provider
+  router (mock / Deepgram / Gladia) closed a real bug and lets the MVP ship on
+  Deepgram with Gladia as a zero-code-change upgrade. The one MEDIUM issue found
+  in review (QA-6.3-C1 — fire-and-forget summary regeneration, unreliable on
+  Vercel) was fixed during review: the PATCH speaker route now awaits the
+  summary chain. 44 tests pass (9 suites), type-check + lint clean. Four LOW
+  items remain as non-blocking follow-ups.
+
+resolved_during_review:
+  - id: QA-6.3-C1
+    title: "Speaker-reassignment summary regeneration was fire-and-forget"
+    severity: MEDIUM
+    resolution: >
+      PATCH /api/recall/sessions/[id]/speakers now awaits runSummarize +
+      maybeAutoGenerateActionItems instead of firing them unawaited, so the
+      regeneration reliably completes on Vercel serverless. maxDuration=120
+      added to the route. Verified by the speakers route test suite.
+    files:
+      - "apps/web/src/app/api/recall/sessions/[id]/speakers/route.ts"
+
+ac_coverage:
+  - ac: "Gladia job submission (recording.done)"
+    status: PASS
+    note: "recording.done → transcribeBotRecording; legacy Deepgram processRecallRecording path removed; ensureSessionRow fallback kept; idempotent via gladia_job_id."
+  - ac: "Gladia webhook callback /api/gladia/webhook"
+    status: PASS
+    note: "Zod-validated; event-discriminated. Auth is a URL shared-secret token, not HMAC — intentional, documented deviation (Gladia v2 does not sign per-job callbacks)."
+  - ac: "Speaker ID mapping (1 / 2 / 3+ cases)"
+    status: PASS
+    note: "map-speakers.ts pure + unit-tested for all cases incl. non-contiguous indices."
+  - ac: "Pipeline integration — updates existing session row"
+    status: PASS
+    note: "handleGladiaDone/processRecallTranscript update the existing row, no double-insert; verified by test."
+  - ac: "finalize-streaming — no eager summary"
+    status: PASS
+    note: "Eager runSummarize removed; 'Generating summary…' state added to the session detail page."
+  - ac: "Failure recovery fallback"
+    status: PASS
+    note: "Streaming-transcript fallback vs transcription_failed + coach email; both branches unit-tested."
+  - ac: "Manual speaker reassignment UI"
+    status: PASS
+    note: "Banner + editor + GET/PATCH route built and tested. Re-summarization now awaited (QA-6.3-C1 resolved)."
+  - ac: "Transcription provider routing (config/env)"
+    status: PASS
+    note: "'gladia' added to TRANSCRIPTION_PROVIDER enum; bot path uses the router. Deepgram fallback added beyond original scope — improvement."
+  - ac: "Quality / standards"
+    status: PASS
+    note: "All files ≤500 lines; no direct process.env; Zod on webhook + PATCH body; no `any`; standard error shape on routes."
+
+critical_issues: []
+
+concerns:
+  - id: QA-6.3-C2
+    title: "Bot session with an empty transcript polls 'Generating summary…' forever"
+    severity: LOW
+    suggested_owner: dev
+    description: >
+      If Gladia/Deepgram returns no utterances, runSummarize returns 'skipped'
+      and never sets sessions.status, leaving it 'pending'. isAwaitingSummary()
+      on the session detail page then returns true indefinitely → 4s polling
+      with no terminal state. Rare (empty recording) but unbounded.
+    fix: >
+      Give the pipeline a terminal signal for the no-content case (set
+      sessions.status when runSummarize skips, or bound isAwaitingSummary by
+      transcript_streaming_complete / elapsed time)."
+
+  - id: QA-6.3-C3
+    title: "Gladia webhook is unauthenticated if GLADIA_WEBHOOK_SECRET is unset"
+    severity: LOW
+    suggested_owner: dev
+    description: >
+      verifyGladiaCallbackToken returns true when no secret is configured. If an
+      operator sets GLADIA_API_KEY but forgets GLADIA_WEBHOOK_SECRET, the
+      callback route accepts unsigned POSTs. Practical risk is low — the handler
+      no-ops unless the body carries a real UUID gladia_job_id — but it is silent.
+    fix: "Warn or hard-fail when GLADIA_API_KEY is set without GLADIA_WEBHOOK_SECRET. Already noted in backlog/gladia-activation.md."
+
+  - id: QA-6.3-C4
+    title: "calendar_events.bot_status not updated by Gladia/Deepgram transitions"
+    severity: LOW
+    suggested_owner: dev
+    description: >
+      The transcription pipeline writes recall_sessions.status directly
+      (transcribing / done / transcription_failed) and bypasses
+      updateRecallSession, which mirrors status to calendar_events.bot_status.
+      A transcription_failed session still shows 'done' on the calendar dashboard.
+    fix: "Mirror terminal transcription status to calendar_events, or document that bot_status reflects only the meeting lifecycle."
+
+  - id: QA-6.3-C5
+    title: "Orphaned legacy code + naming debt"
+    severity: LOW
+    suggested_owner: dev
+    description: >
+      process-recording.ts is no longer referenced (legacy Deepgram bot path).
+      handleGladiaDone and recall_sessions.gladia_job_id are provider-agnostic in
+      practice (store deepgram-* / mock-gladia-* markers). Acknowledged in the
+      story Dev Notes.
+    fix: "Delete process-recording.ts in a follow-up; optionally rename to provider-neutral terms later. Non-urgent."
+
+nfr_validation:
+  security:
+    status: PASS
+    notes: "Clerk auth + ownership checks on the speaker route; Zod on all inputs; callback token compared with timingSafeEqual. QA-6.3-C3 is a low-risk misconfiguration hardening item."
+  performance:
+    status: PASS
+    notes: "Deepgram fallback transcribes inline in the recording.done webhook (maxDuration=300); fine for ~1 hr sessions. Speaker PATCH awaits the AI chain (maxDuration=120). Gladia path is async."
+  reliability:
+    status: PASS
+    notes: "Failure-recovery and idempotency are solid; QA-6.3-C1 fixed during review. QA-6.3-C2 (empty-transcript poll) is a low-severity edge case."
+  maintainability:
+    status: PASS
+    notes: "Files ≤500 lines, cohesive modules, strong comments, no `any`. Naming debt (QA-6.3-C5) is minor and documented."
+
+passed_areas:
+  - "3-way provider router — clean separation, idempotent, mock/Deepgram/Gladia all feed one pipeline"
+  - "Speaker mapping — pure, all speaker-count cases covered + tested"
+  - "Diarized transcript formatter — groups consecutive turns, sorts, tested"
+  - "Failure recovery — degraded-summary vs hard-fail branches, tested"
+  - "Gladia callback handling — Zod-validated, event-discriminated, token-authenticated"
+  - "Pipeline updates the existing streaming session row — no duplicate sessions"
+  - "Speaker reassignment — reformats transcript + re-summarizes (awaited), tested"
+  - "Migration 028 — additive, idempotent (IF NOT EXISTS), status CHECK extended"
+  - "Doc research correctly drove the callback-auth + callback_config deviations"
+  - "TypeScript: 0 errors; ESLint: clean for all changed files"
+
+tests_added_during_review:
+  - "apps/web/src/app/api/recall/sessions/[id]/speakers/__tests__/route.test.ts — speaker reassignment (AC-required, was missing)"
+
+test_summary:
+  total_new: 44
+  suites: 9
+  status: "all passing"
+
+retest_required: false

--- a/docs/stories/6.3.story.md
+++ b/docs/stories/6.3.story.md
@@ -1,7 +1,7 @@
 # Story 6.3: Gladia Transcription Pipeline + Speaker Diarization
 
 ## Status
-Ready for Review
+Done
 
 ## Correction Note (2026-05-17 — Sprint Change Proposal applied)
 
@@ -282,6 +282,7 @@ James (dev) — claude-opus-4-7
 - `apps/web/src/lib/services/transcription/__tests__/deepgram-batch.test.ts`
 - `apps/web/src/lib/services/transcription/__tests__/gladia-service.test.ts`
 - `apps/web/src/app/api/gladia/webhook/__tests__/route.test.ts`
+- `apps/web/src/app/api/recall/sessions/[id]/speakers/__tests__/route.test.ts` (added during QA review)
 
 **Modified:**
 - `apps/web/src/lib/config/env.ts` — `GLADIA_API_KEY`/`GLADIA_WEBHOOK_SECRET`, `config.gladia`, `gladia` in `TRANSCRIPTION_PROVIDER` enum
@@ -299,3 +300,77 @@ James (dev) — claude-opus-4-7
 |------|--------|
 | 2026-05-18 | Story 6.3 implemented — Gladia transcription pipeline, speaker diarization + mapping, re-summarization, speaker reassignment UI. Status → Ready for Review. |
 | 2026-05-18 | Post-review: added Deepgram fallback — bot transcription is a 3-way router (mock / Deepgram / Gladia). Gladia is now opt-in via `GLADIA_API_KEY`; MVP launches on Deepgram. |
+| 2026-05-18 | QA review (Quinn) — gate PASS (92/100). QA-6.3-C1 fixed (speaker re-summarize now awaited); speaker-reassignment route test added. Status → Done. |
+
+## QA Results
+
+### Review Date: 2026-05-18
+
+### Reviewed By: Quinn (Test Architect)
+
+### Gate Decision: PASS — quality score 92/100
+
+Full gate file: `docs/qa/gates/6.3-gladia-transcription.yml`
+(Initial review was CONCERNS; the one MEDIUM issue was fixed during review — see below.)
+
+### Code Quality Assessment
+
+Strong, cohesive implementation. The post-review pivot to a 3-way provider router
+(mock / Deepgram / Gladia) is the right architectural call — it closed a real
+defect (production without a Gladia key would have served the canned fixture) and
+lets the MVP ship on Deepgram with Gladia as a zero-code-change upgrade. Modules
+are small (<500 lines), well-commented, `any`-free; all three providers feed one
+shared pipeline so the diarization UX is provider-independent. Doc research
+correctly drove two AC deviations (token auth instead of a non-existent HMAC
+header; `callback_config` instead of the deprecated `callback_url`).
+
+### Refactoring Performed
+
+None — no unsafe code found. One missing test was added (below).
+
+### Compliance Check
+
+- Coding Standards: ✓ (no direct `process.env`, config object used, Zod on inputs, standard route error shape, no `any`)
+- Project Structure: ✓ (files placed per the story layout; `<500` lines each)
+- Testing Strategy: ✓ unit + integration pyramid; one AC-required test was missing — added during review
+- All ACs Met: ✓ — all AC groups PASS (QA-6.3-C1 fixed during review)
+
+### Improvements Checklist
+
+- [x] Added the missing speaker-reassignment route test (`api/recall/sessions/[id]/speakers/__tests__/route.test.ts`) — AC-required, was absent
+- [x] **QA-6.3-C1 (MEDIUM) — FIXED** — PATCH speaker route now awaits `runSummarize` + `maybeAutoGenerateActionItems` (was fire-and-forget, unreliable on Vercel); `maxDuration=120` added
+- [ ] QA-6.3-C2 (LOW) — empty-transcript bot session polls "Generating summary…" with no terminal state
+- [ ] QA-6.3-C3 (LOW) — warn/fail when `GLADIA_API_KEY` is set without `GLADIA_WEBHOOK_SECRET` (silent unauthenticated callback)
+- [ ] QA-6.3-C4 (LOW) — `calendar_events.bot_status` not mirrored by Gladia/Deepgram status transitions
+- [ ] QA-6.3-C5 (LOW) — delete orphaned `process-recording.ts`
+
+### Security Review
+
+Clerk auth + ownership checks on the speaker route are correct; Zod validates the
+webhook payload and the PATCH body. Callback token auth via `timingSafeEqual` is
+sound. One silent gap: if `GLADIA_WEBHOOK_SECRET` is left unset while Gladia is
+on, the callback route skips verification (QA-6.3-C3) — practical risk low (the
+handler no-ops without a real UUID job id).
+
+### Performance Considerations
+
+Deepgram fallback transcribes inline in the `recording.done` webhook
+(`maxDuration=300`) — acceptable for ~1 hr sessions; the Gladia path is async and
+unaffected. No other performance concerns.
+
+### Files Modified During Review
+
+- **Added:** `apps/web/src/app/api/recall/sessions/[id]/speakers/__tests__/route.test.ts` (7 tests)
+- **Modified:** `apps/web/src/app/api/recall/sessions/[id]/speakers/route.ts` (QA-6.3-C1 fix — awaited re-summarize + `maxDuration`)
+- Both folded into the story File List.
+
+### Gate Status
+
+Gate: PASS → `docs/qa/gates/6.3-gladia-transcription.yml`
+No FAIL/critical issues; QA-6.3-C1 (MEDIUM) fixed during review. 4 LOW follow-ups
+remain (non-blocking). 44 tests pass (9 suites); type-check + lint clean.
+
+### Recommended Status
+
+✓ **Ready for Done** — gate PASS. The 4 LOW items (QA-6.3-C2…C5) are non-blocking
+follow-ups, safe to track separately. Story owner confirms final status.


### PR DESCRIPTION
Post-merge QA review of #83. Gate: **PASS 92/100** (Quinn, Test Architect).

### Changes
- **QA-6.3-C1 fix** — `PATCH /api/recall/sessions/[id]/speakers` now `await`s `runSummarize` + `maybeAutoGenerateActionItems` instead of firing them unawaited. A fire-and-forget call is unreliable on Vercel serverless (the function can freeze after the response). `maxDuration=120` added.
- **New test** — speaker-reassignment route test (7 cases) — the AC-required test that was missing from #83.
- **QA artifacts** — gate file `docs/qa/gates/6.3-gladia-transcription.yml`; QA Results appended to the story; story 6.3 status → Done.
- **Follow-up backlog** — `backlog/6.3-qa-followups.md` documents 4 LOW non-blocking items (QA-6.3-C2…C5).

### Testing
44 tests pass (9 suites); type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)