### PR TITLE
feat(7.4): demo client Alex Rivera + Path B onboarding + QA fixes

### DIFF
--- a/apps/web/migrations/030_story_7_4_demo_client.sql
+++ b/apps/web/migrations/030_story_7_4_demo_client.sql
@@ -1,0 +1,23 @@
+-- 030: Story 7.4 — Demo client "Alex Rivera" + schema groundwork for Story 7.2
+--
+-- Adds is_demo flag + ai_intelligence_strip JSONB to clients. The strip column
+-- is added here (not in 7.2's migration) so the demo seed can pre-populate it;
+-- Story 7.2 will own the read/regenerate logic.
+--
+-- coach_note is NOT added — existing clients.coach_notes (plural; from Story 6.4
+-- migration 20260519_story_6_4_coach_briefs.sql) serves the same purpose and is
+-- already wired through the codebase. Story 7.2 / 7.7 will read/write that.
+
+ALTER TABLE clients
+  ADD COLUMN IF NOT EXISTS is_demo BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS ai_intelligence_strip JSONB;
+
+CREATE INDEX IF NOT EXISTS idx_clients_is_demo
+  ON clients(user_id)
+  WHERE is_demo = TRUE;
+
+COMMENT ON COLUMN clients.is_demo IS
+  'Story 7.4. TRUE for the Alex Rivera demo client seeded into each new user.';
+
+COMMENT ON COLUMN clients.ai_intelligence_strip IS
+  'Story 7.4 (schema + demo seed) / Story 7.2 (regen logic). JSON: {recurring_theme, theme_frequency, recent_breakthrough, current_focus, generated_at}.';

--- a/apps/web/migrations/031_story_7_4_demo_unique.sql
+++ b/apps/web/migrations/031_story_7_4_demo_unique.sql
@@ -1,0 +1,29 @@
+-- 031: Story 7.4 follow-up — enforce one demo client per user.
+--
+-- Closes the race window in seed-demo-client.ts where two concurrent POSTs
+-- could pass the maybeSingle() check and each insert their own demo row.
+-- With this UNIQUE partial index, the second insert raises 23505 and the seed
+-- function falls back to returning the existing row as alreadySeeded.
+--
+-- Migration 030 created the non-unique idx_clients_is_demo for the lookup;
+-- this replaces it with a UNIQUE version covering the same query shape.
+
+-- Defensive: clean up any duplicate demo rows that may have been created
+-- before this constraint existed (keeps the oldest one per user).
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at, id) AS rn
+  FROM clients
+  WHERE is_demo = TRUE
+)
+DELETE FROM clients
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+DROP INDEX IF EXISTS idx_clients_is_demo;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_clients_one_demo_per_user
+  ON clients(user_id)
+  WHERE is_demo = TRUE;
+
+COMMENT ON INDEX uniq_clients_one_demo_per_user IS
+  'Story 7.4. Enforces at most one demo client per user; supports seed-demo-client idempotency lookup.';

--- a/apps/web/src/app/(dashboard)/clients/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/clients/[id]/page.tsx
@@ -189,9 +189,19 @@ export default function ClientDetailPage() {
                 {ini}
               </div>
               <div>
-                <h1 className="text-[22px] font-bold tracking-[-0.02em] text-foreground leading-tight">
-                  {client.name}
-                </h1>
+                <div className="flex items-center gap-2">
+                  <h1 className="text-[22px] font-bold tracking-[-0.02em] text-foreground leading-tight">
+                    {client.name}
+                  </h1>
+                  {client.is_demo && (
+                    <span
+                      title="Demo — explore MeetSolis with this sample client"
+                      className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium text-foreground/55"
+                    >
+                      Demo
+                    </span>
+                  )}
+                </div>
                 {roleCompany && (
                   <div className="flex items-center gap-1.5 mt-1 text-[12px] text-foreground/40">
                     <Building2 className="h-3 w-3 shrink-0" />

--- a/apps/web/src/app/api/onboarding/seed-demo/__tests__/route.test.ts
+++ b/apps/web/src/app/api/onboarding/seed-demo/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment node
+ *
+ * Story 7.4 — POST /api/onboarding/seed-demo tests.
+ */
+
+jest.mock('@/lib/config/env', () => ({
+  config: {
+    supabase: {
+      url: 'http://localhost',
+      serviceRoleKey: 'test-key',
+    },
+  },
+}));
+
+const mockAuth = jest.fn();
+jest.mock('@clerk/nextjs/server', () => ({
+  auth: () => mockAuth(),
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({}),
+}));
+
+const mockGetInternalUserId = jest.fn();
+jest.mock('@/lib/helpers/user', () => ({
+  getInternalUserId: (...args: unknown[]) => mockGetInternalUserId(...args),
+}));
+
+const mockSeedDemoClient = jest.fn();
+jest.mock('@/lib/onboarding/seed-demo-client', () => ({
+  seedDemoClient: (userId: string) => mockSeedDemoClient(userId),
+}));
+
+import { POST } from '../route';
+
+describe('POST /api/onboarding/seed-demo', () => {
+  beforeEach(() => {
+    mockAuth.mockReset();
+    mockGetInternalUserId.mockReset();
+    mockSeedDemoClient.mockReset();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const res = await POST();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 404 when internal user not found', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk-1' });
+    mockGetInternalUserId.mockResolvedValue(null);
+
+    const res = await POST();
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe('USER_NOT_FOUND');
+  });
+
+  it('returns seed result for first-time demo', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk-1' });
+    mockGetInternalUserId.mockResolvedValue('user-1');
+    mockSeedDemoClient.mockResolvedValue({
+      clientId: 'alex-uuid',
+      alreadySeeded: false,
+      sessionsCreated: 4,
+      actionItemsCreated: 8,
+      briefCreated: true,
+    });
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      clientId: 'alex-uuid',
+      alreadySeeded: false,
+      sessionsCreated: 4,
+      actionItemsCreated: 8,
+      briefCreated: true,
+    });
+    expect(mockSeedDemoClient).toHaveBeenCalledWith('user-1');
+  });
+
+  it('is idempotent — returns existing clientId with alreadySeeded=true', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk-1' });
+    mockGetInternalUserId.mockResolvedValue('user-1');
+    mockSeedDemoClient.mockResolvedValue({
+      clientId: 'alex-uuid',
+      alreadySeeded: true,
+      sessionsCreated: 0,
+      actionItemsCreated: 0,
+      briefCreated: false,
+    });
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.alreadySeeded).toBe(true);
+    expect(body.clientId).toBe('alex-uuid');
+  });
+
+  it('returns 500 with generic message (no internal detail leak) when seed throws', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk-1' });
+    mockGetInternalUserId.mockResolvedValue('user-1');
+    mockSeedDemoClient.mockRejectedValue(
+      new Error(
+        'duplicate key value violates constraint "uniq_clients_one_demo_per_user"'
+      )
+    );
+
+    const res = await POST();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+    // Generic message — original error stays in server logs only
+    expect(body.error.message).toBe(
+      'Failed to set up your demo. Please try again.'
+    );
+    expect(body.error.message).not.toContain('duplicate key');
+    expect(body.error.message).not.toContain('uniq_clients');
+  });
+});

--- a/apps/web/src/app/api/onboarding/seed-demo/route.ts
+++ b/apps/web/src/app/api/onboarding/seed-demo/route.ts
@@ -1,0 +1,51 @@
+/**
+ * POST /api/onboarding/seed-demo (Story 7.4)
+ *
+ * Seeds the Alex Rivera demo client + 4 sessions + action items + a coach
+ * brief for the calling user. Idempotent — if a demo client already exists
+ * for this user, returns its `clientId` with `alreadySeeded: true`.
+ *
+ * Called from Path-B onboarding Step 2 (Story 7.3 will mount the trigger).
+ */
+
+import { auth } from '@clerk/nextjs/server';
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse } from 'next/server';
+import { config } from '@/lib/config/env';
+import { getInternalUserId } from '@/lib/helpers/user';
+import { seedDemoClient } from '@/lib/onboarding/seed-demo-client';
+
+export const runtime = 'nodejs';
+
+function err(code: string, message: string, status: number) {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+export async function POST() {
+  try {
+    const { userId: clerkUserId } = await auth();
+    if (!clerkUserId) {
+      return err('UNAUTHORIZED', 'Authentication required', 401);
+    }
+
+    const supabase = createClient(
+      config.supabase.url!,
+      config.supabase.serviceRoleKey!
+    );
+    const userId = await getInternalUserId(supabase, clerkUserId);
+    if (!userId) return err('USER_NOT_FOUND', 'User not found', 404);
+
+    const result = await seedDemoClient(userId);
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (e) {
+    // Log full detail server-side; return a generic message to the client so
+    // Supabase column / constraint names don't leak.
+    console.error('[POST /api/onboarding/seed-demo]', e);
+    return err(
+      'INTERNAL_ERROR',
+      'Failed to set up your demo. Please try again.',
+      500
+    );
+  }
+}

--- a/apps/web/src/components/onboarding/steps/DemoBriefPreview.tsx
+++ b/apps/web/src/components/onboarding/steps/DemoBriefPreview.tsx
@@ -1,0 +1,100 @@
+/**
+ * Story 7.4 — Read-only Coach Brief preview for Step 2B demo tour.
+ *
+ * Mirrors the visual structure of Story 6.4's BriefScreen but takes static
+ * content directly so it renders for Free coaches during onboarding (the real
+ * BriefScreen + /api/brief are Pro-gated). The same content is also seeded
+ * into `coach_briefs` so a coach who upgrades to Pro sees the identical brief
+ * at /brief/manual/{alexClientId}.
+ */
+
+'use client';
+
+import { Sparkles, Calendar, CheckCircle2, Circle } from 'lucide-react';
+import type { CoachBriefContent } from '@meetsolis/shared';
+
+export function DemoBriefPreview({ content }: { content: CoachBriefContent }) {
+  const last = content.last_session;
+  const breakthrough = content.past_breakthroughs[0] ?? null;
+
+  return (
+    <div className="space-y-3">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-primary">
+          Coach Brief
+        </p>
+        <span className="text-[11px] text-foreground/40">·</span>
+        <p className="text-[11px] text-foreground/50">
+          for your session with {content.client_name}
+        </p>
+      </div>
+
+      {/* AI Prep Note */}
+      <section className="rounded-[10px] bg-card px-5 py-4 shadow-card">
+        <div className="mb-2 flex items-center gap-2">
+          <Sparkles className="h-3 w-3 text-primary" />
+          <h2 className="text-[10px] font-semibold uppercase tracking-[0.1em] text-foreground/40">
+            AI Prep Note
+          </h2>
+        </div>
+        <p className="whitespace-pre-line text-[13px] leading-[1.7] text-foreground/85">
+          {content.ai_prep_note}
+        </p>
+      </section>
+
+      {/* Last session */}
+      {last && (
+        <section className="rounded-[10px] bg-card px-5 py-4 shadow-card">
+          <div className="mb-2 flex items-center gap-2">
+            <Calendar className="h-3 w-3 text-foreground/45" />
+            <h2 className="text-[10px] font-semibold uppercase tracking-[0.1em] text-foreground/40">
+              Last session · {last.weeks_ago} weeks ago
+            </h2>
+          </div>
+          <p className="mb-3 text-[13px] font-medium text-foreground/85">
+            {last.key_theme}
+          </p>
+          <ul className="space-y-1.5">
+            {last.action_items.map(item => (
+              <li
+                key={item.id}
+                className="flex items-start gap-2 text-[12.5px] text-foreground/75"
+              >
+                {item.status === 'done' ? (
+                  <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+                ) : (
+                  <Circle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-foreground/35" />
+                )}
+                <span
+                  className={
+                    item.status === 'done'
+                      ? 'text-foreground/40 line-through'
+                      : ''
+                  }
+                >
+                  {item.text}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Past breakthrough */}
+      {breakthrough && (
+        <section className="rounded-[10px] border border-primary/15 bg-primary/[0.04] px-5 py-4">
+          <div className="mb-2 flex items-center gap-2">
+            <Sparkles className="h-3 w-3 text-primary" />
+            <h2 className="text-[10px] font-semibold uppercase tracking-[0.1em] text-primary/70">
+              Past breakthrough
+            </h2>
+          </div>
+          <p className="text-[12.5px] leading-[1.65] text-foreground/80">
+            {breakthrough.summary}
+          </p>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/onboarding/steps/Step2BDemoTour.tsx
+++ b/apps/web/src/components/onboarding/steps/Step2BDemoTour.tsx
@@ -1,0 +1,263 @@
+/**
+ * Story 7.4 — Path B Step 2 — Demo Client Tour (AHA moment).
+ *
+ * Standalone component. Story 7.3 will mount this inside the onboarding shell.
+ *
+ * Flow:
+ *  1. On mount → POST /api/onboarding/seed-demo (idempotent)
+ *  2. Show three "what your card holds" previews — profile, AI Strip, Coach Brief
+ *  3. Offer a Solis pre-filled question as a CTA
+ *  4. "Now add your first real client" → onContinue() (Step 4)
+ *
+ * Tier note: the underlying Coach Brief route is Pro-gated, so this step
+ * renders content from the static demo seed via DemoBriefPreview. The same
+ * brief is also seeded into `coach_briefs` so a Pro coach later sees it at
+ * /brief/manual/{clientId}.
+ */
+
+'use client';
+
+import { useEffect, useMemo } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Sparkles, ArrowRight, MessageSquare, User2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DEMO_CLIENT_PROFILE,
+  buildDemoAIStrip,
+  buildDemoBriefContent,
+} from '@/lib/onboarding/demo-client-data';
+import { DemoBriefPreview } from './DemoBriefPreview';
+
+export interface Step2BDemoTourProps {
+  /** Called when coach clicks "Now add your first real client". */
+  onContinue: () => void;
+  /** Optional — link to the seeded demo client's full card. */
+  onExploreCard?: (clientId: string) => void;
+  /** Optional — open Solis with a pre-filled question against this client. */
+  onAskSolis?: (clientId: string, question: string) => void;
+}
+
+interface SeedResponse {
+  clientId: string;
+  alreadySeeded: boolean;
+}
+
+const SOLIS_PREFILL = 'What is Alex struggling with?';
+
+async function postSeedDemo(): Promise<SeedResponse> {
+  const res = await fetch('/api/onboarding/seed-demo', { method: 'POST' });
+  if (!res.ok) throw new Error(`Seed failed (${res.status})`);
+  return res.json();
+}
+
+export function Step2BDemoTour({
+  onContinue,
+  onExploreCard,
+  onAskSolis,
+}: Step2BDemoTourProps) {
+  const seedMutation = useMutation<SeedResponse, Error>({
+    mutationFn: postSeedDemo,
+  });
+
+  // Fire the seed exactly once on mount. Server-side idempotency + the unique
+  // partial index on (user_id) WHERE is_demo=TRUE handle any race.
+  useEffect(() => {
+    if (seedMutation.isIdle) seedMutation.mutate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const clientId = seedMutation.data?.clientId ?? null;
+  const error = seedMutation.error;
+  const loading = seedMutation.isPending;
+
+  // Static demo content for the previews — same content the seed function
+  // wrote to the database, rendered directly so Free coaches can see the
+  // Coach Brief preview (the real /api/brief route is Pro-only). Memoized so
+  // generated_at doesn't shift on every render.
+  const aiStrip = useMemo(() => buildDemoAIStrip(), []);
+  const briefContent = useMemo(() => buildDemoBriefContent(), []);
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 px-6 py-8">
+      {/* Intro */}
+      <header className="space-y-2 text-center">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-primary">
+          Step 2 of {/* parent will swap in dynamic total */}7
+        </p>
+        <h1 className="text-[26px] font-bold tracking-[-0.02em] text-foreground">
+          Meet your demo client
+        </h1>
+        <p className="text-[14px] text-foreground/55">
+          We&apos;ve set up{' '}
+          <strong className="text-foreground/80">
+            {DEMO_CLIENT_PROFILE.name}
+          </strong>{' '}
+          so you can see what MeetSolis does for you before adding a real
+          client.
+        </p>
+        {loading && (
+          <p className="pt-1 text-[12px] text-foreground/40" role="status">
+            Preparing your demo…
+          </p>
+        )}
+        {error && (
+          <p className="pt-1 text-[12px] text-amber-500" role="status">
+            Could not set up the demo ({error.message}). You can still continue.
+          </p>
+        )}
+      </header>
+
+      {/* Client profile mini-card */}
+      <section className="rounded-[12px] bg-card px-6 py-5 shadow-card">
+        <div className="flex items-center gap-4">
+          <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-primary/15 text-[18px] font-bold text-primary">
+            AR
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <h2 className="text-[18px] font-bold tracking-[-0.01em] text-foreground">
+                {DEMO_CLIENT_PROFILE.name}
+              </h2>
+              <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium text-foreground/55">
+                Demo
+              </span>
+            </div>
+            <p className="mt-0.5 text-[12.5px] text-foreground/45">
+              {DEMO_CLIENT_PROFILE.role} · {DEMO_CLIENT_PROFILE.company}
+            </p>
+            <p className="mt-2 text-[12.5px] leading-[1.55] text-foreground/70">
+              <span className="text-foreground/45">Goal: </span>
+              {DEMO_CLIENT_PROFILE.goal}
+            </p>
+          </div>
+          {clientId && onExploreCard && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onExploreCard(clientId)}
+              className="h-8 shrink-0 gap-1.5 border-border bg-transparent text-[12px]"
+            >
+              <User2 className="h-3.5 w-3.5" />
+              See full card
+            </Button>
+          )}
+        </div>
+      </section>
+
+      {/* AI Intelligence Strip preview */}
+      <section className="rounded-[12px] bg-card px-6 py-5 shadow-card">
+        <div className="mb-3 flex items-center gap-2">
+          <Sparkles className="h-3.5 w-3.5 text-primary" />
+          <h2 className="text-[11px] font-semibold uppercase tracking-[0.12em] text-foreground/40">
+            What your card knows after 4 sessions
+          </h2>
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <StripField
+            label="Recurring theme"
+            value={aiStrip.recurring_theme}
+            chip={aiStrip.theme_frequency}
+          />
+          <StripField
+            label="Recent breakthrough"
+            value={aiStrip.recent_breakthrough}
+          />
+          <StripField label="Current focus" value={aiStrip.current_focus} />
+          <StripField
+            label="Coach note (private)"
+            value="Yours to write. Never touched by AI."
+            muted
+          />
+        </div>
+      </section>
+
+      {/* Coach Brief preview */}
+      <section className="rounded-[12px] border border-border bg-muted/30 px-5 py-5">
+        <p className="mb-3 text-[12px] text-foreground/45">
+          Imagine your session with Alex is in 2 hours. Here&apos;s your brief —
+          generated automatically before every session.
+        </p>
+        <DemoBriefPreview content={briefContent} />
+      </section>
+
+      {/* Solis prompt */}
+      <section className="rounded-[12px] bg-card px-6 py-5 shadow-card">
+        <div className="mb-3 flex items-center gap-2">
+          <MessageSquare className="h-3.5 w-3.5 text-primary" />
+          <h2 className="text-[11px] font-semibold uppercase tracking-[0.12em] text-foreground/40">
+            Try asking Solis
+          </h2>
+        </div>
+        <div className="flex items-center gap-2 rounded-[8px] border border-border bg-muted/60 px-3 py-2">
+          <span className="text-[13px] text-foreground/85">
+            {SOLIS_PREFILL}
+          </span>
+          <div className="ml-auto">
+            {clientId && onAskSolis && (
+              <Button
+                size="sm"
+                onClick={() => onAskSolis(clientId, SOLIS_PREFILL)}
+                className="h-8 gap-1.5 text-[12px]"
+              >
+                Ask Solis
+                <ArrowRight className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </div>
+        </div>
+        <p className="mt-2 text-[11px] text-foreground/40">
+          Solis answers from Alex&apos;s session history — and will do the same
+          for every real client you add.
+        </p>
+      </section>
+
+      {/* Continue */}
+      <div className="flex justify-center pt-2">
+        <Button
+          size="lg"
+          onClick={onContinue}
+          className="h-11 gap-2 px-6 text-[14px] font-semibold"
+        >
+          Now add your first real client
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StripField — small presentational helper, local to this file
+// ---------------------------------------------------------------------------
+
+function StripField({
+  label,
+  value,
+  chip,
+  muted,
+}: {
+  label: string;
+  value: string;
+  chip?: string;
+  muted?: boolean;
+}) {
+  return (
+    <div className="rounded-[8px] border border-border bg-muted/40 px-4 py-3">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.1em] text-foreground/40">
+        {label}
+      </p>
+      <p
+        className={`mt-1.5 text-[13px] leading-[1.55] ${
+          muted ? 'text-foreground/50 italic' : 'text-foreground/85'
+        }`}
+      >
+        {value}
+      </p>
+      {chip && (
+        <p className="mt-1.5 inline-block rounded-full border border-primary/20 bg-primary/[0.06] px-2 py-0.5 text-[10px] text-primary">
+          {chip}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/onboarding/steps/Step4BCreateClient.tsx
+++ b/apps/web/src/components/onboarding/steps/Step4BCreateClient.tsx
@@ -1,0 +1,208 @@
+/**
+ * Story 7.4 — Path B Step 4 — Manual client creation (3 fields only).
+ *
+ * Standalone component; Story 7.3 will mount this inside the onboarding shell.
+ * Per BRAINSTORM §5: name, coaching goal, company. Everything else AI fills in
+ * from sessions.
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { z } from 'zod';
+import { ArrowRight, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { UpgradeRequiredError, type UsageLimitType } from '@meetsolis/shared';
+import { UpgradeModal } from '@/components/billing/UpgradeModal';
+
+const Step4BCreateClientFormSchema = z.object({
+  name: z
+    .string()
+    .min(2, 'Name must be at least 2 characters')
+    .max(100, 'Name must be at most 100 characters')
+    .trim(),
+  goal: z
+    .string()
+    .min(2, 'Tell us what your client is working toward')
+    .max(1000, 'Goal must be at most 1,000 characters')
+    .trim(),
+  company: z.string().max(200).trim().optional(),
+});
+
+type FormData = z.infer<typeof Step4BCreateClientFormSchema>;
+
+export interface Step4BCreateClientProps {
+  /** Called when coach clicks "I'll add one later" — proceeds to Step 5. */
+  onSkip?: () => void;
+}
+
+export function Step4BCreateClient({ onSkip }: Step4BCreateClientProps) {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [upgradeLimitType, setUpgradeLimitType] =
+    useState<UsageLimitType | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<FormData>({
+    resolver: zodResolver(Step4BCreateClientFormSchema),
+    mode: 'onChange',
+    defaultValues: { name: '', goal: '', company: '' },
+  });
+
+  const onSubmit = async (data: FormData) => {
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/clients', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: data.name,
+          goal: data.goal,
+          ...(data.company ? { company: data.company } : {}),
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json();
+        if (res.status === 403 && body.error?.code === 'LIMIT_EXCEEDED') {
+          throw new UpgradeRequiredError(body.error.type as UsageLimitType);
+        }
+        throw new Error(body.error?.message || 'Failed to create client');
+      }
+      const created = (await res.json()) as { id: string };
+      toast.success('Client added');
+      router.push(`/clients/${created.id}`);
+    } catch (e) {
+      if (e instanceof UpgradeRequiredError) {
+        setUpgradeLimitType(e.limitType);
+        return;
+      }
+      const message =
+        e instanceof Error ? e.message : 'Failed to create client';
+      toast.error(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      {upgradeLimitType && (
+        <UpgradeModal
+          isOpen={!!upgradeLimitType}
+          onClose={() => setUpgradeLimitType(null)}
+          limitType={upgradeLimitType}
+        />
+      )}
+
+      <div className="mx-auto w-full max-w-md space-y-6 px-6 py-10">
+        <header className="space-y-2 text-center">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-primary">
+            Step 4 of 7
+          </p>
+          <h1 className="text-[26px] font-bold tracking-[-0.02em] text-foreground">
+            Add your first real client
+          </h1>
+          <p className="text-[14px] text-foreground/55">
+            Three fields. MeetSolis fills in everything else from your sessions.
+          </p>
+        </header>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="name"
+              className="text-[12px] font-medium text-foreground/70"
+            >
+              Name <span className="text-red-400">*</span>
+            </Label>
+            <Input
+              id="name"
+              {...register('name')}
+              autoFocus
+              placeholder="e.g. Sarah Chen"
+              className="h-10"
+            />
+            {errors.name && (
+              <p className="text-[12px] text-red-400">{errors.name.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="goal"
+              className="text-[12px] font-medium text-foreground/70"
+            >
+              Coaching goal <span className="text-red-400">*</span>
+            </Label>
+            <Textarea
+              id="goal"
+              {...register('goal')}
+              placeholder="What is this client working toward?"
+              rows={3}
+            />
+            {errors.goal && (
+              <p className="text-[12px] text-red-400">{errors.goal.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="company"
+              className="text-[12px] font-medium text-foreground/70"
+            >
+              Company <span className="text-foreground/35">(optional)</span>
+            </Label>
+            <Input
+              id="company"
+              {...register('company')}
+              placeholder="e.g. Acme Logistics"
+              className="h-10"
+            />
+            {errors.company && (
+              <p className="text-[12px] text-red-400">
+                {errors.company.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2 pt-2">
+            <Button
+              type="submit"
+              size="lg"
+              disabled={!isValid || submitting}
+              className="h-11 gap-2 text-[14px] font-semibold"
+            >
+              {submitting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ArrowRight className="h-4 w-4" />
+              )}
+              Add client
+            </Button>
+            {onSkip && (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={onSkip}
+                disabled={submitting}
+                className="h-10 text-[13px] text-foreground/55 hover:text-foreground"
+              >
+                I&apos;ll add a client later
+              </Button>
+            )}
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/lib/onboarding/__tests__/demo-client-data.test.ts
+++ b/apps/web/src/lib/onboarding/__tests__/demo-client-data.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Story 7.4 — demo-client-data shape sanity checks.
+ *
+ * Keeps the quarterly content review honest by catching structural drift —
+ * wrong session count, wrong assignee enum, dates that are no longer in the
+ * expected ranges relative to the seed time.
+ */
+
+import {
+  DEMO_CLIENT_PROFILE,
+  DEMO_ACTION_ITEMS,
+  buildDemoSessions,
+  buildDemoAIStrip,
+  buildDemoBriefContent,
+  demoDates,
+} from '../demo-client-data';
+import { AIIntelligenceStripSchema } from '@meetsolis/shared';
+
+describe('DEMO_CLIENT_PROFILE', () => {
+  it('has the locked persona fields', () => {
+    expect(DEMO_CLIENT_PROFILE.name).toBe('Alex Rivera');
+    expect(DEMO_CLIENT_PROFILE.role).toBe('VP Engineering');
+    expect(DEMO_CLIENT_PROFILE.company).toBeTruthy();
+    expect(DEMO_CLIENT_PROFILE.goal.length).toBeGreaterThan(20);
+  });
+});
+
+describe('buildDemoSessions', () => {
+  const seedAt = new Date('2026-06-01T12:00:00Z');
+  const sessions = buildDemoSessions(seedAt);
+
+  it('produces exactly 4 sessions per BRAINSTORM §5', () => {
+    expect(sessions).toHaveLength(4);
+  });
+
+  it('sessions span ~3 months with the latest ~2 weeks before seedAt', () => {
+    const dates = sessions.map(s => new Date(s.session_date).getTime());
+    const oldest = new Date(dates[0]).getTime();
+    const newest = new Date(dates[3]).getTime();
+    const monthsBetween = (newest - oldest) / (30 * 24 * 60 * 60 * 1000);
+    expect(monthsBetween).toBeGreaterThan(2.5);
+    expect(monthsBetween).toBeLessThan(3.5);
+
+    const weeksBeforeSeed =
+      (seedAt.getTime() - newest) / (7 * 24 * 60 * 60 * 1000);
+    expect(weeksBeforeSeed).toBeGreaterThan(1.5);
+    expect(weeksBeforeSeed).toBeLessThan(2.5);
+  });
+
+  it('every session has a title, summary, transcript and key_topics', () => {
+    sessions.forEach(s => {
+      expect(s.title.length).toBeGreaterThan(10);
+      expect(s.summary.length).toBeGreaterThan(50);
+      expect(s.transcript_text.length).toBeGreaterThan(300);
+      expect(s.key_topics.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('avoids dated cultural / public-figure references', () => {
+    const blocklist = [
+      'COVID',
+      'pandemic',
+      'OpenAI',
+      'Elon',
+      'ChatGPT',
+      'TikTok',
+    ];
+    sessions.forEach(s => {
+      const haystack = `${s.title} ${s.summary} ${s.transcript_text}`;
+      blocklist.forEach(banned => {
+        expect(haystack.toLowerCase()).not.toContain(banned.toLowerCase());
+      });
+    });
+  });
+});
+
+describe('DEMO_ACTION_ITEMS', () => {
+  it('has at least one completed and one open item — coach feels both states', () => {
+    const completed = DEMO_ACTION_ITEMS.filter(i => i.completed).length;
+    const open = DEMO_ACTION_ITEMS.filter(i => !i.completed).length;
+    expect(completed).toBeGreaterThan(0);
+    expect(open).toBeGreaterThan(0);
+  });
+
+  it('mixes coach and client assignees', () => {
+    const coach = DEMO_ACTION_ITEMS.filter(i => i.assignee === 'coach').length;
+    const client = DEMO_ACTION_ITEMS.filter(
+      i => i.assignee === 'client'
+    ).length;
+    expect(coach).toBeGreaterThan(0);
+    expect(client).toBeGreaterThan(0);
+  });
+
+  it('all sessionIndex values are 0..3', () => {
+    DEMO_ACTION_ITEMS.forEach(i => {
+      expect([0, 1, 2, 3]).toContain(i.sessionIndex);
+    });
+  });
+});
+
+describe('buildDemoAIStrip', () => {
+  it('returns a strip that conforms to AIIntelligenceStripSchema', () => {
+    const strip = buildDemoAIStrip();
+    const parsed = AIIntelligenceStripSchema.safeParse(strip);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('all strip fields are non-empty and specific', () => {
+    const strip = buildDemoAIStrip();
+    expect(strip.recurring_theme.length).toBeGreaterThan(10);
+    expect(strip.theme_frequency).toMatch(/\d/); // contains a number
+    expect(strip.recent_breakthrough.length).toBeGreaterThan(10);
+    expect(strip.current_focus.length).toBeGreaterThan(10);
+  });
+});
+
+describe('buildDemoBriefContent', () => {
+  it('shapes match CoachBriefContent (Story 6.4)', () => {
+    const c = buildDemoBriefContent();
+    expect(c.client_name).toBe('Alex Rivera');
+    expect(c.minutes_until_session).toBeNull(); // manual brief
+    expect(c.is_first_session).toBe(false);
+    expect(c.last_session).not.toBeNull();
+    expect(c.past_breakthroughs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('action_items in last_session use ids passed in', () => {
+    const fakeItems = [
+      { id: 'item-a', text: 'open thing', completed: false },
+      { id: 'item-b', text: 'done thing', completed: true },
+    ];
+    const c = buildDemoBriefContent(
+      new Date(),
+      'session-3-uuid',
+      'session-4-uuid',
+      fakeItems
+    );
+    expect(c.last_session!.session_id).toBe('session-4-uuid');
+    expect(c.last_session!.action_items.map(a => a.id)).toEqual([
+      'item-a',
+      'item-b',
+    ]);
+    expect(c.last_session!.action_items.map(a => a.status)).toEqual([
+      'open',
+      'done',
+    ]);
+  });
+});
+
+describe('demoDates', () => {
+  it('returns YYYY-MM-DD strings for all 5 dates', () => {
+    const d = demoDates(new Date('2026-06-01T00:00:00Z'));
+    Object.values(d).forEach(date => {
+      expect(date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+});

--- a/apps/web/src/lib/onboarding/__tests__/seed-demo-client.test.ts
+++ b/apps/web/src/lib/onboarding/__tests__/seed-demo-client.test.ts
@@ -1,0 +1,311 @@
+/**
+ * @jest-environment node
+ *
+ * Story 7.4 — seed-demo-client tests.
+ *
+ * Covers idempotency, the multi-table insert sequence, embedding generation
+ * fallback when the AI provider throws, and the brief-failure non-fatal path.
+ */
+
+jest.mock('@/lib/config/env', () => ({
+  config: {
+    supabase: {
+      url: 'http://localhost',
+      serviceRoleKey: 'test-key',
+    },
+  },
+}));
+
+const mockGenerateEmbedding = jest.fn();
+jest.mock('@/lib/service-factory', () => ({
+  ServiceFactory: {
+    createAIService: () => ({
+      generateEmbedding: (text: string) => mockGenerateEmbedding(text),
+    }),
+  },
+}));
+
+// Supabase mock — single in-test state object so each call inspects what we want.
+type Row = Record<string, unknown>;
+interface MockState {
+  existingDemoClient: Row | null;
+  /** Existing row that maybeSingle returns AFTER a 23505 conflict — simulates a winning concurrent seed. */
+  postConflictExisting: Row | null;
+  insertedClient: Row | null;
+  insertedSessions: Row[];
+  insertedItems: Row[];
+  insertedBrief: Row | null;
+  briefInsertError: { message: string } | null;
+  clientInsertError: { message: string; code?: string } | null;
+  sessionInsertError: { message: string } | null;
+}
+
+const state: MockState = {
+  existingDemoClient: null,
+  postConflictExisting: null,
+  insertedClient: null,
+  insertedSessions: [],
+  insertedItems: [],
+  insertedBrief: null,
+  briefInsertError: null,
+  clientInsertError: null,
+  sessionInsertError: null,
+};
+
+function resetState() {
+  state.existingDemoClient = null;
+  state.postConflictExisting = null;
+  state.insertedClient = null;
+  state.insertedSessions = [];
+  state.insertedItems = [];
+  state.insertedBrief = null;
+  state.briefInsertError = null;
+  state.clientInsertError = null;
+  state.sessionInsertError = null;
+}
+
+function fromBuilder(table: string) {
+  let action: 'select' | 'insert' = 'select';
+  let insertedRow: Row | Row[] | null = null;
+
+  const builder = {
+    select() {
+      return builder;
+    },
+    eq() {
+      return builder;
+    },
+    async maybeSingle() {
+      if (table === 'clients') {
+        // First maybeSingle in seedDemoClient is the pre-insert idempotency
+        // check. The second (only if clientInsertError code is 23505) is the
+        // post-race fallback lookup — switch which row we return based on
+        // whether we've already consumed the pre-insert check.
+        if (state.existingDemoClient) {
+          const row = state.existingDemoClient;
+          state.existingDemoClient = null; // consume
+          return { data: row, error: null };
+        }
+        if (state.postConflictExisting) {
+          return { data: state.postConflictExisting, error: null };
+        }
+      }
+      return { data: null, error: null };
+    },
+    insert(row: Row | Row[]) {
+      action = 'insert';
+      insertedRow = row;
+
+      if (table === 'clients') {
+        if (state.clientInsertError) {
+          return {
+            select: () => ({
+              single: async () => ({
+                data: null,
+                error: state.clientInsertError,
+              }),
+            }),
+          };
+        }
+        state.insertedClient = row as Row;
+        return {
+          select: () => ({
+            single: async () => ({
+              data: { id: 'demo-client-uuid' },
+              error: null,
+            }),
+          }),
+        };
+      }
+
+      if (table === 'sessions') {
+        if (state.sessionInsertError) {
+          return {
+            select: () => ({
+              single: async () => ({
+                data: null,
+                error: state.sessionInsertError,
+              }),
+            }),
+          };
+        }
+        const i = state.insertedSessions.length;
+        state.insertedSessions.push(row as Row);
+        return {
+          select: () => ({
+            single: async () => ({
+              data: { id: `session-uuid-${i}` },
+              error: null,
+            }),
+          }),
+        };
+      }
+
+      if (table === 'action_items') {
+        const rows = Array.isArray(row) ? row : [row];
+        state.insertedItems.push(...rows);
+        return {
+          select: async () => ({
+            data: rows.map((r, i) => ({
+              id: `item-uuid-${i}`,
+              session_id: r.session_id,
+              description: r.description,
+              completed: r.completed,
+            })),
+            error: null,
+          }),
+        };
+      }
+
+      if (table === 'coach_briefs') {
+        if (state.briefInsertError) {
+          return Promise.resolve({ error: state.briefInsertError });
+        }
+        state.insertedBrief = row as Row;
+        return Promise.resolve({ error: null });
+      }
+
+      return Promise.resolve({ error: null });
+    },
+  };
+
+  // action_items.insert returns the chain directly; satisfies thenable consumers.
+  return builder;
+}
+
+const mockSupabaseClient = {
+  from: jest.fn(fromBuilder),
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => mockSupabaseClient,
+}));
+
+import { seedDemoClient } from '../seed-demo-client';
+
+describe('seedDemoClient', () => {
+  beforeEach(() => {
+    resetState();
+    mockGenerateEmbedding.mockReset();
+    mockGenerateEmbedding.mockResolvedValue(new Array(1536).fill(0.01));
+    mockSupabaseClient.from.mockClear();
+  });
+
+  it('returns alreadySeeded when user already has an is_demo client', async () => {
+    state.existingDemoClient = { id: 'existing-demo-uuid' };
+
+    const res = await seedDemoClient('user-1');
+
+    expect(res).toEqual({
+      clientId: 'existing-demo-uuid',
+      alreadySeeded: true,
+      sessionsCreated: 0,
+      actionItemsCreated: 0,
+      briefCreated: false,
+    });
+    expect(mockGenerateEmbedding).not.toHaveBeenCalled();
+  });
+
+  it('inserts 1 client + 4 sessions + 8 action items + 1 brief on first run', async () => {
+    const res = await seedDemoClient('user-1');
+
+    expect(res.alreadySeeded).toBe(false);
+    expect(res.clientId).toBe('demo-client-uuid');
+    expect(res.sessionsCreated).toBe(4);
+    expect(res.actionItemsCreated).toBe(8);
+    expect(res.briefCreated).toBe(true);
+
+    // Client row has is_demo + ai_intelligence_strip
+    expect(state.insertedClient).toMatchObject({
+      user_id: 'user-1',
+      name: 'Alex Rivera',
+      is_demo: true,
+    });
+    expect(state.insertedClient?.ai_intelligence_strip).toBeDefined();
+
+    // 4 sessions, all linked to demo client, all status=complete
+    expect(state.insertedSessions).toHaveLength(4);
+    state.insertedSessions.forEach(s => {
+      expect(s.client_id).toBe('demo-client-uuid');
+      expect(s.user_id).toBe('user-1');
+      expect(s.status).toBe('complete');
+      expect(s.source).toBe('manual');
+      // Embedding stored as JSON-stringified array (Story 3 pattern)
+      expect(typeof s.embedding).toBe('string');
+    });
+
+    // Embedding called once per session
+    expect(mockGenerateEmbedding).toHaveBeenCalledTimes(4);
+
+    // 8 action items, mix of completed and not
+    expect(state.insertedItems).toHaveLength(8);
+    const completedCount = state.insertedItems.filter(i => i.completed).length;
+    expect(completedCount).toBeGreaterThan(0);
+    expect(completedCount).toBeLessThan(8);
+
+    // Brief inserted with content + null calendar_event_id (manual brief)
+    expect(state.insertedBrief).toMatchObject({
+      user_id: 'user-1',
+      client_id: 'demo-client-uuid',
+      calendar_event_id: null,
+      generation_status: 'ok',
+    });
+    expect(state.insertedBrief?.content).toBeDefined();
+  });
+
+  it('falls back to zero-vector embedding when AI service throws', async () => {
+    mockGenerateEmbedding.mockRejectedValue(new Error('AI down'));
+
+    const res = await seedDemoClient('user-1');
+
+    expect(res.sessionsCreated).toBe(4);
+    expect(mockGenerateEmbedding).toHaveBeenCalledTimes(4);
+    // Each stored embedding is a 1536-length zero vector
+    state.insertedSessions.forEach(s => {
+      const arr = JSON.parse(s.embedding as string);
+      expect(arr).toHaveLength(1536);
+      expect(arr.every((x: number) => x === 0)).toBe(true);
+    });
+  });
+
+  it('returns briefCreated=false but still succeeds if brief insert errors', async () => {
+    state.briefInsertError = { message: 'brief failed' };
+
+    const res = await seedDemoClient('user-1');
+
+    expect(res.clientId).toBe('demo-client-uuid');
+    expect(res.sessionsCreated).toBe(4);
+    expect(res.actionItemsCreated).toBe(8);
+    expect(res.briefCreated).toBe(false);
+  });
+
+  it('throws when client insert fails (fatal)', async () => {
+    state.clientInsertError = { message: 'client insert failed' };
+
+    await expect(seedDemoClient('user-1')).rejects.toThrow(
+      /failed to insert client/
+    );
+    expect(state.insertedSessions).toHaveLength(0);
+  });
+
+  it('handles 23505 unique violation by returning the winning concurrent demo as alreadySeeded', async () => {
+    // Pre-insert idempotency check returns null (race: both calls saw empty)
+    state.existingDemoClient = null;
+    // Insert hits the UNIQUE partial index from migration 031
+    state.clientInsertError = { code: '23505', message: 'duplicate key' };
+    // Post-conflict re-fetch finds the row inserted by the concurrent call
+    state.postConflictExisting = { id: 'winner-demo-uuid' };
+
+    const res = await seedDemoClient('user-1');
+
+    expect(res).toEqual({
+      clientId: 'winner-demo-uuid',
+      alreadySeeded: true,
+      sessionsCreated: 0,
+      actionItemsCreated: 0,
+      briefCreated: false,
+    });
+    // We should NOT have proceeded to insert sessions
+    expect(state.insertedSessions).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/onboarding/demo-client-data.ts
+++ b/apps/web/src/lib/onboarding/demo-client-data.ts
@@ -1,0 +1,343 @@
+/**
+ * Story 7.4 — Demo client "Alex Rivera" static content.
+ *
+ * Hand-written so the demo is deterministic, zero per-signup AI cost, and high
+ * quality. Seeded into each new Path-B user via seed-demo-client.ts.
+ *
+ * Content quality rubric (BRAINSTORM §5, §13):
+ *  - Generic exec-coaching themes (leadership presence, delegation, team dynamics)
+ *  - Believable persona — VP Engineering at a fictional mid-size company
+ *  - Sessions show progression: problem → exploration → breakthrough → consolidation
+ *  - No real company / public-figure references
+ *  - No dated cultural references
+ *
+ * Quarterly review: refresh if content feels stale.
+ */
+
+import type { CoachBriefContent } from '@meetsolis/shared';
+import type { AIIntelligenceStrip } from '@meetsolis/shared';
+
+// ---------------------------------------------------------------------------
+// Date helpers — anchored at seed time so the demo always feels "recent"
+// ---------------------------------------------------------------------------
+
+export function demoDates(seedAt: Date = new Date()) {
+  const d = (daysAgo: number) => {
+    const out = new Date(seedAt);
+    out.setUTCDate(out.getUTCDate() - daysAgo);
+    return out.toISOString().slice(0, 10); // YYYY-MM-DD
+  };
+  return {
+    startDate: d(90), // ~3 months ago — coaching engagement start
+    session1: d(90), // Session 1 — goal-setting
+    session2: d(60), // Session 2 — exec presence emerges (~2 months ago)
+    session3: d(30), // Session 3 — breakthrough (~1 month ago)
+    session4: d(14), // Session 4 — continued work (~2 weeks ago)
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Client profile
+// ---------------------------------------------------------------------------
+
+export const DEMO_CLIENT_PROFILE = {
+  name: 'Alex Rivera',
+  role: 'VP Engineering',
+  company: 'Northridge Logistics',
+  goal: 'Step into executive presence and build a stronger leadership voice with the senior team.',
+  email: null as string | null,
+} as const;
+
+// ---------------------------------------------------------------------------
+// AI Intelligence Strip (pre-populated)
+// ---------------------------------------------------------------------------
+
+export function buildDemoAIStrip(
+  seedAt: Date = new Date()
+): AIIntelligenceStrip {
+  return {
+    recurring_theme:
+      'Executive presence — speaking with authority in senior rooms',
+    theme_frequency: 'Present in 3 of 4 sessions',
+    recent_breakthrough:
+      'Delivered the Q3 all-hands talk without retreating into technical detail — first time landing a vision-level message',
+    current_focus:
+      'Translating exec presence into peer-level influence with the CFO and CRO, not just downward leadership',
+    generated_at: seedAt.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sessions — 4 sessions, ~3-month arc, biweekly-to-monthly cadence
+// ---------------------------------------------------------------------------
+
+export interface DemoSession {
+  title: string;
+  session_date: string; // YYYY-MM-DD
+  transcript_text: string;
+  summary: string;
+  key_topics: string[];
+}
+
+export function buildDemoSessions(seedAt: Date = new Date()): DemoSession[] {
+  const d = demoDates(seedAt);
+  return [
+    // ---------- Session 1 — Goal-setting ----------
+    {
+      title: 'Goal-setting — defining what "executive presence" means to Alex',
+      session_date: d.session1,
+      transcript_text: [
+        'Coach: Welcome, Alex. Before we get into anything tactical, I want to understand what brought you to coaching now.',
+        'Alex: My CEO told me directly — I need to grow into the VP role, not just hold the title. She said I run engineering well but I disappear in senior conversations. I default to listening when I should be shaping the room.',
+        'Coach: When she said that, what was the first reaction in your body?',
+        'Alex: Honestly, defensive. Then about ten minutes later — recognition. She is right. I prep for one-on-ones. I do not prep for all-hands. I do not prep for leadership offsites. I treat them like I am still a senior engineer attending, not leading.',
+        'Coach: What would it look like if you were leading those rooms instead of attending them?',
+        'Alex: I would have a point of view going in. I would be willing to disagree with the CFO out loud. I would talk about strategy, not implementation. I would stop translating every business question into a technical answer.',
+        'Coach: That last one is interesting. Say more about that habit.',
+        'Alex: Someone asks "should we acquire Mercer?" and I immediately think about their codebase. The CEO does not need that. She needs whether the engineering org can absorb the integration in nine months without breaking shipping velocity. Different question.',
+        'Coach: What feels at stake if you keep operating the way you have been?',
+        'Alex: I plateau. I stay a really good director-level operator with a VP title. And eventually they bring in someone over me to do the work I should be doing.',
+        'Coach: For the next three months, what is the working definition of executive presence you want to build toward?',
+        'Alex: Going into senior rooms with a thesis. Holding the thesis under pressure. Speaking to the business outcome, not the implementation. Being someone the CEO can put in front of the board.',
+      ].join('\n\n'),
+      summary:
+        'Initial session. Alex named the gap between his director-level execution and the VP-level presence his CEO is asking for. Working definition of executive presence: enter senior rooms with a thesis, hold it under pressure, speak to business outcomes not implementation. Pattern noticed: defaults to translating business questions into technical answers.',
+      key_topics: [
+        'executive presence',
+        'CEO feedback',
+        'leadership identity',
+        'goal-setting',
+      ],
+    },
+
+    // ---------- Session 2 — Exec presence theme emerges ----------
+    {
+      title:
+        'Exec presence under pressure — the M&A leadership offsite debrief',
+      session_date: d.session2,
+      transcript_text: [
+        'Coach: You said before we started that this past week was rough. Where do you want to start?',
+        "Alex: The leadership offsite. M&A topic came up — the Mercer acquisition I mentioned last time. CFO pitched it. CEO turned to me. And I — I went into the codebase again. I started talking about their tech stack and integration timelines. I watched the CEO's face shift and I knew.",
+        'Coach: What did the shift look like?',
+        'Alex: She went from leaning forward to leaning back. Polite nod. Then she moved the conversation along.',
+        'Coach: What were you feeling in that moment?',
+        'Alex: Like I had just demoted myself in front of the whole leadership team. And then for the rest of the offsite I overcorrected — talked too much, too loud, on topics I had no business weighing in on.',
+        'Coach: What is the pattern you are seeing?',
+        'Alex: I default to safe ground when I feel exposed. The safe ground for me is technical. And then when I realize I look small, I overcompensate by talking more. Neither of those is presence.',
+        'Coach: If you could rerun that moment with the CFO, what would you have said instead?',
+        'Alex: Probably — "the question I would want to answer before we move is whether we can integrate them without breaking our Q4 commitments to existing enterprise customers. That is the engineering risk. The tech stack risk is solvable. The roadmap displacement is what would actually hurt us." That is a VP answer.',
+        'Coach: What stopped you from saying that in the room?',
+        'Alex: I had not thought about it that way until just now. I had not prepared for the M&A topic at all. I prepared for the org structure discussion. So when the CFO opened that door, I had no thesis, and I retreated to what I knew.',
+        'Coach: So the gap is not presence. The gap is preparation for the strategic conversation, not just the operational one.',
+        'Alex: Yes. That lands. I prepare like a director — meeting agendas, status updates. I do not prepare like a VP — thesis, point of view, anticipated counter-arguments.',
+      ].join('\n\n'),
+      summary:
+        'Alex debriefed the M&A leadership offsite where he defaulted to technical detail under pressure with the CFO, then overcompensated. Key insight: the gap is not presence itself but the kind of preparation done before senior rooms. He prepares operationally; he needs to prepare strategically — thesis, point of view, anticipated counter-arguments.',
+      key_topics: [
+        'executive presence',
+        'M&A discussion',
+        'leadership preparation',
+        'defaulting to technical',
+        'CFO dynamics',
+      ],
+    },
+
+    // ---------- Session 3 — Breakthrough ----------
+    {
+      title: 'Breakthrough — landing the Q3 all-hands talk',
+      session_date: d.session3,
+      transcript_text: [
+        'Coach: You came in smiling. That is not the usual entrance.',
+        'Alex: All-hands was Tuesday. I gave a fifteen-minute opening on what engineering is doing this quarter. And it landed.',
+        'Coach: Walk me through what landed mean to you.',
+        'Alex: People stayed in their seats. Slack lit up afterward. Two of my own senior engineers messaged me — they said it was the first time they understood why we are doing the platform rebuild. The CFO came up to me after. He said it was the clearest he has heard the engineering strategy in two years.',
+        'Coach: What did you do differently?',
+        'Alex: Prepared like a VP, finally. I wrote the thesis first — "we are rebuilding the platform because our enterprise customers are starting to ask questions our current architecture cannot answer." Everything else flowed from that. I did not show any code. I did not show any architecture diagrams. I showed two customer quotes and one chart of roadmap displacement risk. That was it.',
+        'Coach: What was that like for you — standing up there without the technical scaffolding?',
+        'Alex: Exposed at first. I rehearsed three times the night before because I kept reaching for the architecture slide. But by the time I was up there I felt steady. Not because the slides were strong — because the thesis was right and I knew it.',
+        'Coach: That is the difference. You held the thesis under pressure.',
+        'Alex: Yes. And here is what surprised me. The Q&A was the easy part. Once the thesis was clear, every question routed back to it. Even when finance pushed on budget, I could answer from the thesis instead of getting pulled into implementation cost details.',
+        'Coach: What does this tell you about the work going forward?',
+        'Alex: That the leverage point is the thirty minutes I spend writing the thesis before any senior conversation. Not the conversation itself. The conversation is downstream of preparation. I had been treating it as the other way around.',
+        'Coach: How do you want to operationalize that?',
+        'Alex: Standing thirty-minute block on my calendar before any leadership meeting. No exceptions. I write the thesis, the two anticipated push-backs, and my answer to each. If I do not have a thesis by the end of the thirty minutes, I cancel my attendance.',
+      ].join('\n\n'),
+      summary:
+        'Breakthrough session. Alex delivered the Q3 all-hands talk holding a strategic thesis instead of retreating to technical detail. CFO praised it as the clearest engineering strategy framing in two years. Insight: the leverage is in the thirty-minute thesis-writing block before any senior conversation, not in the conversation itself. Committed to a standing thesis-prep block before every leadership meeting.',
+      key_topics: [
+        'executive presence',
+        'all-hands speaking',
+        'thesis-driven communication',
+        'CFO recognition',
+        'thesis preparation ritual',
+      ],
+    },
+
+    // ---------- Session 4 — Consolidation + new edge ----------
+    {
+      title: 'Peer-level influence — extending presence to the CFO and CRO',
+      session_date: d.session4,
+      transcript_text: [
+        'Coach: How is the thesis-prep block holding up?',
+        'Alex: Three weeks in. Held every time. It is the highest-leverage thirty minutes of my week.',
+        'Coach: Where is your edge now?',
+        'Alex: Downward and to the CEO, I feel solid. The room where I still shrink is peer level — the CFO and the CRO. We meet weekly as a senior team. I lead engineering well in that room. I do not push back on revenue strategy or capital allocation. And they do not push back on engineering. We are all polite. Nothing moves.',
+        'Coach: What is the cost of polite?',
+        'Alex: We made a hiring plan last quarter that I knew was wrong. I had a view that we were over-investing in field engineering and under-investing in platform. I did not bring it up because the CRO had pitched it and the CFO had signed off. So I executed something I did not believe in. We are paying for that now — platform is bottlenecked, field engineers are underutilized.',
+        'Coach: What kept you from speaking up?',
+        'Alex: I had a thesis. I had prep. I just — did not want the conflict. The CRO is more senior in the company by years. I respect him. I told myself "trust the team." But trust is not the same as silence.',
+        'Coach: Where else have you used "trust the team" as cover for not bringing your view?',
+        'Alex: Probably more places than I want to admit. Roadmap prioritization with the CRO last month. Budget reallocation conversation with the CFO two weeks ago. Same pattern. I had a view. I sat on it. I told myself I was deferring to expertise.',
+        'Coach: What is the difference between deferring to expertise and avoiding peer conflict?',
+        'Alex: Deferring to expertise — I would say "you are closer to revenue, what is your read?" and then engage with their answer. Avoiding conflict — I do not bring my view at all. I have been doing the second and telling myself it is the first.',
+        'Coach: What is the next concrete experiment?',
+        'Alex: In the next weekly senior team meeting, I bring my platform-vs-field view to the CRO directly. I do not soften it. I do not bury it in the agenda. I open with "here is something I think we got wrong last quarter and what I would change going forward."',
+        'Coach: What is the version of you that walks into that meeting?',
+        'Alex: The one who held the thesis at all-hands. Not a different person. Just that one, but pointed sideways instead of outward.',
+      ].join('\n\n'),
+      summary:
+        'Alex consolidated the thesis-prep ritual (3 weeks of standing 30-min blocks before leadership meetings). New edge identified: peer-level influence with CFO and CRO. He has been mistaking "trust the team" for avoiding peer conflict. Concrete example: executed a Q-prior hiring plan he knew was wrong because he did not push back on the CRO. Committed to bringing his platform-vs-field view directly to the CRO in the next senior team meeting, opening with "here is something I think we got wrong."',
+      key_topics: [
+        'peer-level influence',
+        'CFO and CRO dynamics',
+        'avoiding conflict',
+        'trust the team as cover',
+        'thesis prep ritual sustained',
+      ],
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Action items per session — mix of coach + client assignees, mix of completed
+// ---------------------------------------------------------------------------
+
+export interface DemoActionItemSeed {
+  sessionIndex: 0 | 1 | 2 | 3;
+  description: string;
+  assignee: 'coach' | 'client';
+  completed: boolean;
+}
+
+export const DEMO_ACTION_ITEMS: DemoActionItemSeed[] = [
+  // Session 1
+  {
+    sessionIndex: 0,
+    description:
+      'Write a one-paragraph working definition of executive presence for Alex to react to next session',
+    assignee: 'coach',
+    completed: true,
+  },
+  {
+    sessionIndex: 0,
+    description:
+      'Notice and journal one moment per week where Alex translates a business question into a technical answer',
+    assignee: 'client',
+    completed: true,
+  },
+  // Session 2
+  {
+    sessionIndex: 1,
+    description:
+      'Before the next senior leadership meeting, write a one-page thesis: position, two anticipated counter-arguments, response to each',
+    assignee: 'client',
+    completed: true,
+  },
+  {
+    sessionIndex: 1,
+    description:
+      'Send Alex two short readings on strategic vs operational preparation by Friday',
+    assignee: 'coach',
+    completed: true,
+  },
+  // Session 3
+  {
+    sessionIndex: 2,
+    description:
+      'Block a recurring 30-minute thesis-prep slot on the calendar before every leadership meeting — no exceptions',
+    assignee: 'client',
+    completed: true,
+  },
+  {
+    sessionIndex: 2,
+    description: 'Share the all-hands talk transcript with Alex by end of week',
+    assignee: 'coach',
+    completed: false,
+  },
+  // Session 4 (open — recent)
+  {
+    sessionIndex: 3,
+    description:
+      'In the next weekly senior team meeting, bring the platform-vs-field view directly to the CRO without softening',
+    assignee: 'client',
+    completed: false,
+  },
+  {
+    sessionIndex: 3,
+    description:
+      'Draft three observations on peer-conflict avoidance patterns Alex named, send before next session',
+    assignee: 'coach',
+    completed: false,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Coach Brief — pre-generated, mirrors Story 6.4 CoachBriefContent shape
+// ---------------------------------------------------------------------------
+
+export function buildDemoBriefContent(
+  seedAt: Date = new Date(),
+  session3Id?: string,
+  session4Id?: string,
+  session4ActionItemIds: { id: string; text: string; completed: boolean }[] = []
+): CoachBriefContent {
+  const d = demoDates(seedAt);
+  return {
+    client_name: DEMO_CLIENT_PROFILE.name,
+    minutes_until_session: null, // manual brief — no calendar event
+    last_session: {
+      session_id: session4Id ?? '00000000-0000-0000-0000-000000000000',
+      date: d.session4,
+      weeks_ago: 2,
+      action_items: session4ActionItemIds.length
+        ? session4ActionItemIds.map(a => ({
+            id: a.id,
+            text: a.text,
+            status: a.completed ? ('done' as const) : ('open' as const),
+          }))
+        : [
+            {
+              id: '00000000-0000-0000-0000-000000000000',
+              text: 'In the next weekly senior team meeting, bring the platform-vs-field view directly to the CRO without softening',
+              status: 'open' as const,
+            },
+            {
+              id: '00000000-0000-0000-0000-000000000000',
+              text: 'Draft three observations on peer-conflict avoidance patterns Alex named, send before next session',
+              status: 'open' as const,
+            },
+          ],
+      key_theme:
+        'Peer-level influence — extending presence sideways, not just downward',
+    },
+    ai_prep_note: [
+      "Alex made a clear leap last session — he now sees 'trust the team' as cover for avoiding peer conflict, especially with the CFO and CRO. The thesis-prep ritual is holding (3 weeks). The new work is using that thesis sideways, not just in all-hands or with the CEO.",
+      '',
+      'Watch for: he may report on whether he brought the platform-vs-field view to the CRO. If he did, dig into how the CRO received it and what Alex felt during. If he did not, the conversation is about what he told himself instead — and whether the avoidance pattern is shrinking or just relocating.',
+      '',
+      'Possible opening: "Last time we ended on the platform-vs-field conversation with the CRO. What happened with that?"',
+    ].join('\n'),
+    past_breakthroughs: [
+      {
+        session_id: session3Id ?? '00000000-0000-0000-0000-000000000000',
+        date: d.session3,
+        summary:
+          'Q3 all-hands talk landed. Held a strategic thesis without retreating to technical detail. CFO praised it. Alex identified the leverage point — the 30-minute thesis-prep block before any senior room.',
+      },
+    ],
+    coach_open_questions: '',
+    is_first_session: false,
+    suggested_questions: [],
+    edited_fields: [],
+  };
+}

--- a/apps/web/src/lib/onboarding/seed-demo-client.ts
+++ b/apps/web/src/lib/onboarding/seed-demo-client.ts
@@ -1,0 +1,232 @@
+/**
+ * Story 7.4 — Seed the "Alex Rivera" demo client for a new Path-B user.
+ *
+ * Idempotent: if the user already has an `is_demo = true` client, returns its
+ * ID without re-seeding. Embeddings are generated through the configured AI
+ * service (zero-vector under the claude provider — see story note A3); Solis's
+ * hybrid search still surfaces results via the keyword side of the ranking.
+ *
+ * Per-signup cost: ~$0.001 (4 OpenAI embedding calls). Brief content is
+ * hand-written into demo-client-data.ts — no per-signup brief generation.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { config } from '@/lib/config/env';
+import { ServiceFactory } from '@/lib/service-factory';
+import {
+  DEMO_CLIENT_PROFILE,
+  buildDemoAIStrip,
+  buildDemoSessions,
+  DEMO_ACTION_ITEMS,
+  buildDemoBriefContent,
+  demoDates,
+} from './demo-client-data';
+
+export interface SeedDemoResult {
+  clientId: string;
+  alreadySeeded: boolean;
+  sessionsCreated: number;
+  actionItemsCreated: number;
+  briefCreated: boolean;
+}
+
+function getSupabase() {
+  return createClient(config.supabase.url!, config.supabase.serviceRoleKey!);
+}
+
+/**
+ * Seeds Alex Rivera + 4 sessions + 8 action items + 1 coach brief for the
+ * given internal user UUID. Safe to call repeatedly — returns existing
+ * `clientId` with `alreadySeeded: true` if the demo client already exists.
+ */
+export async function seedDemoClient(userId: string): Promise<SeedDemoResult> {
+  const supabase = getSupabase();
+
+  // ---- Idempotency check ------------------------------------------------
+  const { data: existing } = await supabase
+    .from('clients')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('is_demo', true)
+    .maybeSingle();
+
+  if (existing?.id) {
+    return {
+      clientId: existing.id,
+      alreadySeeded: true,
+      sessionsCreated: 0,
+      actionItemsCreated: 0,
+      briefCreated: false,
+    };
+  }
+
+  const seedAt = new Date();
+  const dates = demoDates(seedAt);
+  const aiStrip = buildDemoAIStrip(seedAt);
+  const sessions = buildDemoSessions(seedAt);
+
+  // ---- 1. Insert client -------------------------------------------------
+  const { data: insertedClient, error: clientErr } = await supabase
+    .from('clients')
+    .insert({
+      user_id: userId,
+      name: DEMO_CLIENT_PROFILE.name,
+      role: DEMO_CLIENT_PROFILE.role,
+      company: DEMO_CLIENT_PROFILE.company,
+      goal: DEMO_CLIENT_PROFILE.goal,
+      start_date: dates.startDate,
+      is_demo: true,
+      ai_intelligence_strip: aiStrip,
+      // last_session_at mirrors the latest session below so the client card
+      // shows realistic "last session" copy immediately.
+      last_session_at: new Date(`${dates.session4}T12:00:00Z`).toISOString(),
+    })
+    .select('id')
+    .single();
+
+  if (clientErr || !insertedClient) {
+    // 23505 = Postgres unique_violation. With migration 031's UNIQUE partial
+    // index on (user_id) WHERE is_demo=TRUE, a concurrent seed wins the race
+    // and our insert hits the constraint. Re-fetch the winning row and treat
+    // as alreadySeeded — same outcome as the read-side idempotency check.
+    if (clientErr?.code === '23505') {
+      const { data: existingAfterRace } = await supabase
+        .from('clients')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('is_demo', true)
+        .maybeSingle();
+      if (existingAfterRace?.id) {
+        return {
+          clientId: existingAfterRace.id,
+          alreadySeeded: true,
+          sessionsCreated: 0,
+          actionItemsCreated: 0,
+          briefCreated: false,
+        };
+      }
+    }
+    throw new Error(
+      `seed-demo-client: failed to insert client — ${clientErr?.message}`
+    );
+  }
+  const clientId = insertedClient.id as string;
+
+  // ---- 2. Insert sessions + embeddings ---------------------------------
+  const aiService = ServiceFactory.createAIService();
+  const insertedSessionIds: string[] = [];
+
+  for (const session of sessions) {
+    // Generate embedding off the summary (matches Story 3 summarize-session
+    // pattern). Under the claude provider this is a zero-vector; Solis still
+    // works via the keyword half of hybrid search.
+    let embedding: number[] = [];
+    try {
+      embedding = await aiService.generateEmbedding(session.summary);
+    } catch (e) {
+      console.error('[seed-demo-client] embedding failed (non-fatal):', e);
+      embedding = new Array(1536).fill(0);
+    }
+
+    const { data: insertedSession, error: sErr } = await supabase
+      .from('sessions')
+      .insert({
+        user_id: userId,
+        client_id: clientId,
+        title: session.title,
+        session_date: session.session_date,
+        transcript_text: session.transcript_text,
+        summary: session.summary,
+        key_topics: session.key_topics,
+        embedding: JSON.stringify(embedding),
+        status: 'complete',
+        source: 'manual',
+      })
+      .select('id')
+      .single();
+
+    if (sErr || !insertedSession) {
+      throw new Error(
+        `seed-demo-client: failed to insert session "${session.title}" — ${sErr?.message}`
+      );
+    }
+    insertedSessionIds.push(insertedSession.id as string);
+  }
+
+  // ---- 3. Insert action items ------------------------------------------
+  const itemRows = DEMO_ACTION_ITEMS.map(item => {
+    const sessionId = insertedSessionIds[item.sessionIndex];
+    const completedAt = item.completed ? new Date().toISOString() : null;
+    return {
+      user_id: userId,
+      client_id: clientId,
+      session_id: sessionId,
+      description: item.description,
+      assignee: item.assignee,
+      completed: item.completed,
+      completed_at: completedAt,
+      status: item.completed ? 'completed' : 'pending',
+    };
+  });
+
+  const { data: insertedItems, error: itemsErr } = await supabase
+    .from('action_items')
+    .insert(itemRows)
+    .select('id, session_id, description, completed');
+
+  if (itemsErr) {
+    throw new Error(
+      `seed-demo-client: failed to insert action items — ${itemsErr.message}`
+    );
+  }
+  const actionItemsCreated = insertedItems?.length ?? 0;
+
+  // ---- 4. Insert coach brief -------------------------------------------
+  // Use real IDs (session 3 = breakthrough; session 4 = last session) and the
+  // action items belonging to session 4 so the BriefScreen can render
+  // checkboxes against the live action_items table.
+  const session3Id = insertedSessionIds[2];
+  const session4Id = insertedSessionIds[3];
+  const session4Items =
+    insertedItems
+      ?.filter(i => i.session_id === session4Id)
+      .map(i => ({
+        id: i.id as string,
+        text: i.description as string,
+        completed: i.completed as boolean,
+      })) ?? [];
+
+  const briefContent = buildDemoBriefContent(
+    seedAt,
+    session3Id,
+    session4Id,
+    session4Items
+  );
+
+  const { error: briefErr } = await supabase.from('coach_briefs').insert({
+    user_id: userId,
+    client_id: clientId,
+    calendar_event_id: null, // manual brief
+    content: briefContent,
+    generation_status: 'ok',
+    dismissed: false,
+    generated_at: seedAt.toISOString(),
+  });
+
+  if (briefErr) {
+    // Brief failure is non-fatal — client and sessions are seeded; coach can
+    // regenerate from /brief/manual/{clientId}. Log and continue.
+    console.error(
+      '[seed-demo-client] coach_briefs insert failed (non-fatal):',
+      briefErr.message
+    );
+  }
+
+  return {
+    clientId,
+    alreadySeeded: false,
+    sessionsCreated: insertedSessionIds.length,
+    actionItemsCreated,
+    briefCreated: !briefErr,
+  };
+}

--- a/docs/qa/gates/7.4-demo-client-path-b.yml
+++ b/docs/qa/gates/7.4-demo-client-path-b.yml
@@ -1,0 +1,189 @@
+schema: 1
+story: '7.4'
+story_title: 'Demo Client "Alex Rivera" + Onboarding Path B'
+gate: PASS
+status_reason: 'Migration applied. Seed + API + Step components shipped with idempotency, embedding fallback, and 23/23 tests passing. Pattern divergence (useEffect fetch) and race-window on double-seed noted as low-severity concerns; neither blocks ship.'
+reviewer: 'Quinn (Test Architect)'
+updated: '2026-05-30T00:00:00Z'
+
+quality_score: 90
+expires: '2026-06-13T00:00:00Z'
+
+top_issues:
+  - id: MAINT-001
+    severity: low
+    title: 'Step2BDemoTour uses fetch-in-useEffect instead of react-query useMutation'
+    refs: ['apps/web/src/components/onboarding/steps/Step2BDemoTour.tsx:58-78']
+    rationale: |
+      Project CLAUDE.md says "Data fetching: @tanstack/react-query — never fetch in useEffect."
+      Step 2B issues a POST in useEffect to trigger the seed. Server-side idempotency makes the
+      practical risk minor (dupes return alreadySeeded; cost is bounded), and the cancel flag
+      handles unmount races. Still a convention violation worth fixing before 7.3 mounts the
+      component into the live onboarding shell.
+    suggested_owner: dev
+    fix: 'Convert to useMutation; trigger via mutate() in a one-shot useEffect that only fires when mutation is idle.'
+  - id: MAINT-002
+    severity: low
+    title: 'Idempotency lookup is not atomic — double-click could create two demo clients'
+    refs:
+      - 'apps/web/migrations/030_story_7_4_demo_client.sql:15-17 (partial index is NOT unique)'
+      - 'apps/web/src/lib/onboarding/seed-demo-client.ts:47-66 (read-then-write window)'
+    rationale: |
+      Two concurrent POSTs from the same user could both pass the maybeSingle() check before
+      either inserts. Outcome: two demo clients (deletable, no data corruption). UX impact
+      small but real if a coach refreshes Step 2B mid-seed. Add a UNIQUE partial constraint:
+      CREATE UNIQUE INDEX uniq_clients_one_demo_per_user ON clients(user_id) WHERE is_demo = TRUE
+      Then catch the conflict in the seed function and treat as alreadySeeded.
+    suggested_owner: dev
+  - id: SEC-001
+    severity: low
+    title: 'API error response echoes raw error.message to caller'
+    refs: ['apps/web/src/app/api/onboarding/seed-demo/route.ts:41-45']
+    rationale: |
+      INTERNAL_ERROR returns e.message verbatim. Supabase errors can expose column / constraint
+      names to an authed caller. Low severity (caller is already inside Clerk auth), but
+      generic client message + full server log is the standard pattern.
+    suggested_owner: dev
+    fix: 'console.error(e); return err("INTERNAL_ERROR", "Failed to set up your demo. Please try again.", 500);'
+
+waiver: { active: false }
+
+evidence:
+  tests_reviewed: 23
+  risks_identified: 3
+  trace:
+    ac_covered: [
+      'migration-030',
+      'demo-client-data-static',
+      'seed-function-idempotency',
+      'seed-function-embeddings',
+      'seed-function-brief-failure-non-fatal',
+      'api-route-auth',
+      'api-route-idempotent',
+      'demo-badge-render',
+      'step2b-standalone',
+      'step4b-standalone',
+      'demobriefpreview-standalone'
+    ]
+    ac_gaps: [
+      'step2b-component-mount-test',
+      'step4b-component-mount-test',
+      'demobriefpreview-snapshot-test'
+    ]
+
+ac_trace:
+  - ac: 'Migration 030 adds is_demo + ai_intelligence_strip; reuses existing coach_notes'
+    status: PASS
+    refs:
+      - 'apps/web/migrations/030_story_7_4_demo_client.sql'
+      - 'Verified user-applied to Supabase before QA'
+    notes: 'Original spec asked for new coach_note column; dev correctly chose to reuse existing clients.coach_notes (Story 6.4) — decision documented in spec amendment + dev completion notes. 7.2 + 7.7 specs propagated 2026-05-30.'
+  - ac: 'demo-client-data.ts exports DEMO_CLIENT/SESSIONS/ITEMS/BRIEF/STRIP, no real-company refs, no dated cultural refs'
+    status: PASS
+    refs:
+      - 'apps/web/src/lib/onboarding/demo-client-data.ts'
+      - 'apps/web/src/lib/onboarding/__tests__/demo-client-data.test.ts'
+    notes: 'Blocklist test catches COVID/pandemic/OpenAI/Elon/ChatGPT/TikTok. Persona (VP Eng at fictional Northridge Logistics) is generic. Theme arc shows progression (problem → exploration → breakthrough → next edge). AI Strip phrasings are specific not generic ("Executive presence — present in 3 of 4 sessions"). Content quality is founder-review territory; structural sanity is covered.'
+  - ac: 'Seed function: idempotent, embeds, inserts client+sessions+items+brief, returns counts'
+    status: PASS
+    refs:
+      - 'apps/web/src/lib/onboarding/seed-demo-client.ts'
+      - 'apps/web/src/lib/onboarding/__tests__/seed-demo-client.test.ts'
+    notes: '5 test cases including alreadySeeded, embedding fallback, brief-failure-non-fatal, fatal client-insert error.'
+  - ac: 'POST /api/onboarding/seed-demo: Clerk auth, idempotent, error envelope'
+    status: PASS
+    refs:
+      - 'apps/web/src/app/api/onboarding/seed-demo/route.ts'
+      - 'apps/web/src/app/api/onboarding/seed-demo/__tests__/route.test.ts'
+    notes: '5 test cases including 401, 404, success, alreadySeeded, 500.'
+  - ac: 'Demo badge on Client Card detail when client.is_demo'
+    status: PASS
+    refs: ['apps/web/src/app/(dashboard)/clients/[id]/page.tsx:191-202']
+    notes: 'Subtle outline chip + title-attr tooltip. File now 421 lines (under 500). No additional render cost when is_demo is false.'
+  - ac: 'Step2BDemoTour — calls seed on mount, renders profile + strip + brief preview + Solis prefill'
+    status: CONCERNS
+    refs: ['apps/web/src/components/onboarding/steps/Step2BDemoTour.tsx']
+    notes: 'Pattern divergence (MAINT-001 — useEffect fetch). Functionally correct; component is currently unmounted (waiting on Story 7.3 shell) so no live impact.'
+  - ac: 'Step4BCreateClient — 3-field form (name, goal, company), redirects to new client page'
+    status: PASS
+    refs: ['apps/web/src/components/onboarding/steps/Step4BCreateClient.tsx']
+    notes: 'react-hook-form + zodResolver, UpgradeModal for limit hits, sonner toast.'
+  - ac: 'DemoBriefPreview — read-only mirror of BriefScreen for Free coach onboarding'
+    status: PASS
+    refs: ['apps/web/src/components/onboarding/steps/DemoBriefPreview.tsx']
+    notes: 'Smart workaround for tier-gated /api/brief. Same content seeded into coach_briefs so Pro coach later sees identical at /brief/manual/{clientId}.'
+  - ac: 'Counts toward tier limits — no special-case in checkClientLimit'
+    status: PASS
+    refs: ['apps/web/src/lib/billing/checkUsage.ts (unchanged) + grep of is_demo']
+    notes: 'No filter on is_demo in client count queries. Demo client is counted normally — intended per BRAINSTORM §5.'
+  - ac: 'Quality: tsc clean, no any, files ≤500 lines'
+    status: PASS
+    refs:
+      - 'tsc exit 0 confirmed during review'
+      - 'wc -l: demo-client-data.ts=331, Step2B=260, DemoBriefPreview=98, Step4B=178, seed=210'
+    notes: 'All files comfortably under 500.'
+
+nfr_validation:
+  security:
+    status: CONCERNS
+    notes: 'SEC-001 (low): API echoes raw error.message. Clerk auth + internal user resolution otherwise sound. No new attack surface beyond authed seed-once endpoint.'
+  performance:
+    status: PASS
+    notes: 'Per-signup cost ~$0.001 (4 OpenAI embeddings). Brief gen $0 (hand-written). Bundle delta from demo-client-data static content is server-side only. Minor PERF nit: buildDemoAIStrip()/buildDemoBriefContent() recompute per render in Step 2B (defer with useMemo if mount churn matters).'
+  reliability:
+    status: CONCERNS
+    notes: 'MAINT-002 (low): non-atomic idempotency. Brief-failure non-fatal path is correct. Session/item insert failures throw fatally — leaves orphan client+earlier-sessions. Acceptable for demo (deletable, low blast radius).'
+  maintainability:
+    status: CONCERNS
+    notes: 'MAINT-001 (low): useEffect fetch in Step 2B violates project pattern. Convert to useMutation before 7.3 mounts the component.'
+
+testability:
+  controllability: PASS
+  observability: PASS
+  debuggability: PASS
+
+compliance_check:
+  coding_standards: PASS
+  project_structure: PASS
+  testing_strategy: CONCERNS
+  all_acs_met: PASS
+
+recommendations:
+  immediate: []
+  future:
+    - action: 'Convert Step2BDemoTour seed call from fetch+useEffect to useMutation'
+      refs: ['apps/web/src/components/onboarding/steps/Step2BDemoTour.tsx:58-78']
+      rationale: 'Project CLAUDE.md convention. Best done before Story 7.3 mounts the component.'
+    - action: 'Add UNIQUE partial index for one-demo-per-user'
+      refs: ['apps/web/migrations/030_story_7_4_demo_client.sql']
+      rationale: 'Closes the double-seed race window. Tiny migration follow-up.'
+    - action: 'Genericify INTERNAL_ERROR client message; log full error server-side'
+      refs: ['apps/web/src/app/api/onboarding/seed-demo/route.ts:41-45']
+      rationale: 'Standard production hardening; low severity but trivial fix.'
+    - action: 'Add component mount tests for Step2BDemoTour, Step4BCreateClient, DemoBriefPreview'
+      rationale: 'Round out testing pyramid. Data layer is solid; UI smoke tests would close the trace gap.'
+    - action: 'Memoize buildDemoAIStrip / buildDemoBriefContent in Step2BDemoTour'
+      refs: ['apps/web/src/components/onboarding/steps/Step2BDemoTour.tsx:83-84']
+      rationale: 'Eliminate per-render recompute. Cosmetic.'
+
+review_notes: |
+  Story 7.4 shipped clean against the locked decisions:
+  - Brief = real Story 6.4 content, hand-written, seeded → ✓ (DemoBriefPreview workaround for tier-gated /api/brief is the right call for Free coaches mid-onboarding; Pro coaches still see the same content at /brief/manual/{clientId})
+  - is_demo badge → ✓
+  - Counts toward tier limits → ✓ (no special-case)
+  - "Re-add demo" Settings CTA SKIPPED → ✓
+  - Per-signup cost ~$0.001 (4 OpenAI embeddings) → matches spec note
+
+  The coach_note → coach_notes column reuse decision is a net positive — avoids
+  duplicating intent of the existing Story 6.4 column. Propagated correctly to
+  7.2 + 7.7 specs before this review.
+
+  Demo content quality is founder-review territory; the structural sanity test
+  (blocklist for dated/real-company references; assignee mix; 4-session count;
+  3-month span) catches drift. Content prose itself should be eyeballed before
+  ship; that wasn't part of QA's authority.
+
+  Story 7.3 still owes a shell mount for Step 2B + Step 4B + the redirect
+  middleware before this story's UX is end-user-reachable. Until then, the
+  /onboarding route still hosts the legacy Story 1.8 flow which 7.3 will
+  delete + replace. Not a blocker for 7.4 — story scope is delivered.

--- a/docs/stories/7.2.story.md
+++ b/docs/stories/7.2.story.md
@@ -7,7 +7,9 @@ Draft
 
 Grounded against current `main`:
 
-- **A1. `clients` table missing `coach_note` and `ai_intelligence_strip` columns** — confirmed via `apps/web/migrations/014_create_clients_table.sql` + `015_v3_schema.sql`. Migration in this story adds both. **Do NOT reuse the existing `notes` column** — that field is the legacy generic notes from Story 2.1 (free-text, mixed-purpose). The new `coach_note TEXT` is the strip-specific private field. Keep them separate; consider migrating/deprecating `notes` in a later story if desired (out of scope here).
+- **A1. (Updated 2026-05-30 during 7.4 dev)** Original draft said add new `coach_notes` column. **Decision flipped:** reuse existing `clients.coach_notes` (plural) — already added by Story 6.4 (`apps/web/supabase/migrations/20260519_story_6_4_coach_briefs.sql`) as `text NOT NULL DEFAULT ''`. Comment on that column already reads "private per-client coach notes, persists across sessions, never AI-touched" — exactly this story's intent. Adding a parallel `coach_notes` (singular) column would duplicate the field. **`ai_intelligence_strip JSONB` was added by Story 7.4's migration 030** (groundwork). Net: this story adds NO new columns; it only ships the regen logic, API routes, and UI.
+
+  **Do NOT reuse the legacy `clients.notes` column** — that is the generic notes field from Story 2.1 (free-text, mixed-purpose). `coach_notes` is the strip-specific private field. Consider migrating/deprecating `notes` in a later story if desired (out of scope here).
 - **A2. `clients.overview` and `clients.research_data` already exist** (from Epic 4 — leftover from old "client research" feature). Do NOT touch. Future story may reclaim them; not this one.
 - **A3. Strip generation hook** — `apps/web/src/lib/sessions/summarize-session.ts` is the right place per spec. Add `await generateIntelligenceStrip(clientId)` AFTER `sessions.update({ status: 'complete' })` (line 70 area). Fire-and-forget — wrap in `try/catch` and log to Sentry; never block session-summary success on strip-gen failure.
 - **A4. AI service abstraction** — use `ServiceFactory.createAIService()` pattern (see `summarize-session.ts:50`). Add new method `generateIntelligenceStrip(input)` to `IAIService` interface in `apps/web/src/lib/services/ai/` (claude + openai + mock implementations). Do NOT instantiate Anthropic/OpenAI clients directly.
@@ -20,7 +22,7 @@ Grounded against current `main`:
 ## Locked Decisions (from BRAINSTORM.md §2)
 - **Lock-in mechanic** — card gets richer every session; coach cannot leave without losing intelligence layer
 - **AI editability principle (non-negotiable)** — every AI field editable inline; coach override wins
-- **`coach_note` is NEVER touched by AI** — not on first gen, not on regen, not ever
+- **`coach_notes` is NEVER touched by AI** — not on first gen, not on regen, not ever
 - **Generation timing**: after every session processed; manual "Refresh" button available
 - **Output format**: specific, not generic ("Imposter syndrome — 5 of 8 sessions" not "client has recurring themes")
 - **Strip available to all tiers** — lock-in serves both Free→Pro conversion AND Pro retention
@@ -42,10 +44,10 @@ Grounded against current `main`:
 - Toast: `sonner` Toaster already in dashboard root
 
 **What's new:**
-- 2 new columns on `clients`: `ai_intelligence_strip JSONB`, `coach_note TEXT`
+- ~~2 new columns on `clients`: `ai_intelligence_strip JSONB`, `coach_notes TEXT`~~ (Updated 2026-05-30: both already exist — strip from Story 7.4 migration 030, coach_notes from Story 6.4)
 - New function `generateIntelligenceStrip(clientId)`
 - New AI service method `generateIntelligenceStrip(input)` (Claude + OpenAI + mock)
-- New API routes: `POST /api/clients/[id]/intelligence-strip`, `PATCH /api/clients/[id]/intelligence-strip`, `PATCH /api/clients/[id]/coach-note`
+- New API routes: `POST /api/clients/[id]/intelligence-strip`, `PATCH /api/clients/[id]/intelligence-strip`, `PATCH /api/clients/[id]/coach-notes`
 - New component: `AIIntelligenceStrip.tsx`
 - Hook into `summarize-session.ts`
 
@@ -57,18 +59,10 @@ Grounded against current `main`:
 
 ## Acceptance Criteria
 
-### Data Model (Migration 030)
-- [ ] `apps/web/migrations/030_story_7_2_intelligence_strip.sql`:
-  ```sql
-  ALTER TABLE clients
-    ADD COLUMN IF NOT EXISTS ai_intelligence_strip JSONB,
-    ADD COLUMN IF NOT EXISTS coach_note TEXT;
-  COMMENT ON COLUMN clients.ai_intelligence_strip IS
-    'Story 7.2. JSON: {recurring_theme, theme_frequency, recent_breakthrough, current_focus, generated_at}';
-  COMMENT ON COLUMN clients.coach_note IS
-    'Story 7.2. Private coach-only note. NEVER touched by AI under any condition.';
-  ```
-- [ ] Shared type `AIIntelligenceStrip` added to `packages/shared/src/types/client.ts`:
+### Data Model — NO new migration in this story (groundwork shipped in 7.4 migration 030)
+- [x] `clients.ai_intelligence_strip JSONB` already added by `apps/web/migrations/030_story_7_4_demo_client.sql` (Story 7.4)
+- [x] `clients.coach_notes` (plural) already added by `apps/web/supabase/migrations/20260519_story_6_4_coach_briefs.sql` (Story 6.4)
+- [x] Shared type `AIIntelligenceStrip` exported from `packages/shared/src/schemas/client.ts` (added by Story 7.4):
   ```ts
   export type AIIntelligenceStrip = {
     recurring_theme: string;
@@ -78,7 +72,8 @@ Grounded against current `main`:
     generated_at: string; // ISO
   };
   ```
-- [ ] `Client` type extended with `ai_intelligence_strip: AIIntelligenceStrip | null` and `coach_note: string | null`
+- [x] `ClientSchema.is_demo` + `ClientSchema.ai_intelligence_strip` already extended by Story 7.4
+- [ ] **Confirm** `Client` type already exposes `coach_notes: string | null` via `ClientSchema` (Story 6.4) — no change needed here
 
 ### Generation (Server-side)
 - [ ] New: `apps/web/src/lib/clients/generate-intelligence-strip.ts`
@@ -112,9 +107,9 @@ Grounded against current `main`:
   - Body: partial of `AIIntelligenceStrip` (any field except `generated_at`)
   - Zod validates; merges into existing JSONB
   - Returns updated strip
-- [ ] `PATCH /api/clients/[id]/coach-note` — save coach note separately
-  - Body: `{ coach_note: string }` (max 5000 chars)
-  - Returns `{ coach_note: string }`
+- [ ] `PATCH /api/clients/[id]/coach-notes` — save coach note separately
+  - Body: `{ coach_notes: string }` (max 5000 chars)
+  - Returns `{ coach_notes: string }`
 - [ ] All routes use standard error handler + Clerk auth + Zod input validation + no `process.env` direct
 
 ### UI — `AIIntelligenceStrip.tsx`
@@ -144,9 +139,9 @@ Grounded against current `main`:
 - [ ] Tests:
   - Unit: `generate-intelligence-strip.ts` with mock AI service
   - Unit: Zod schema rejects malformed AI output
-  - Unit: coach_note PATCH never touches `ai_intelligence_strip`
+  - Unit: coach_notes PATCH never touches `ai_intelligence_strip`
   - Integration: `POST /api/clients/[id]/intelligence-strip` returns 403 for Free coach (button hidden client-side, defense-in-depth)
-  - Integration: regen does NOT overwrite coach_note (load fixture with coach_note → POST regen → assert coach_note unchanged)
+  - Integration: regen does NOT overwrite coach_notes (load fixture with coach_notes → POST regen → assert coach_notes unchanged)
 
 ## Technical Notes
 
@@ -158,7 +153,7 @@ apps/web/src/lib/clients/__tests__/generate-intelligence-strip.test.ts          
 apps/web/src/lib/clients/__tests__/generate-intelligence-strip.fixtures.md            # NEW (prompt gate evidence)
 apps/web/src/app/api/clients/[id]/intelligence-strip/route.ts                         # NEW
 apps/web/src/app/api/clients/[id]/intelligence-strip/__tests__/route.test.ts          # NEW
-apps/web/src/app/api/clients/[id]/coach-note/route.ts                                 # NEW
+apps/web/src/app/api/clients/[id]/coach-notes/route.ts                                 # NEW
 apps/web/src/components/client/AIIntelligenceStrip.tsx                                # NEW
 apps/web/src/components/client/__tests__/AIIntelligenceStrip.test.tsx                 # NEW
 apps/web/src/app/(dashboard)/clients/[id]/page.tsx                                    # MOD (insert strip + extract if >450 lines)
@@ -227,7 +222,7 @@ Rules:
 - Strip versioning / history (only latest stored)
 - Bulk regenerate across all clients
 - Strip preview before save (current model: regen overwrites; coach can edit any field after)
-- Migrating legacy `clients.notes` into `coach_note` (separate cleanup story)
+- Migrating legacy `clients.notes` into `coach_notes` (separate cleanup story)
 
 ## Estimated Effort
 **1.5 days.** Migration + types (0.2d), AI service + generation function (0.5d), prompt validation against 10 transcripts (0.3d), API routes (0.2d), UI component + inline edit (0.3d).

--- a/docs/stories/7.4.story.md
+++ b/docs/stories/7.4.story.md
@@ -1,7 +1,7 @@
 # Story 7.4: Demo Client "Alex Rivera" + Onboarding Path B
 
 ## Status
-Draft
+Ready for Review
 
 ## Precheck Amendments (2026-05-27) — PM-resolved
 
@@ -233,19 +233,131 @@ _(Q2 locked 2026-05-30. Q1, Q3, Q4 are minor; lock during dev.)_
 ## Dev Agent Record
 
 ### Agent Model Used
-_(to be filled by dev)_
+claude-opus-4-7 (James — BMad dev agent)
 
 ### Completion Notes
-_(to be filled by dev)_
+
+**Schema reuse — `coach_notes` vs `coach_note`:** the spec called for adding a new `clients.coach_note` (singular) column. `clients.coach_notes` (plural, `text NOT NULL DEFAULT ''`) **already exists** from Story 6.4 (`apps/web/supabase/migrations/20260519_story_6_4_coach_briefs.sql`). Adding a parallel column would duplicate intent and confuse 7.2/7.7. **Decision:** reuse existing `coach_notes`. Migration 030 only adds `is_demo` + `ai_intelligence_strip`. **Action needed for 7.2 + 7.7 prechecks:** swap references from `coach_note` → `coach_notes`.
+
+**Brief preview for Free coaches:** `/brief/*` and `GET /api/brief` are Pro-only (line 100 of `apps/web/src/app/api/brief/route.ts` returns `state: 'upgrade_required'` for Free). Path B onboarding happens BEFORE upgrade. To deliver the locked decision "render Story 6.4's real component reading from a seeded `coach_briefs` row" for a Free coach mid-onboarding, I built a thin read-only preview component (`DemoBriefPreview.tsx`) that mirrors `BriefScreen`'s visual structure using the same demo brief content. Same content is seeded into `coach_briefs` so a Pro coach later sees an identical brief at `/brief/manual/{alexClientId}`. Net effect: AHA moment lands for Free + Pro alike.
+
+**Embedding provider quirk (A3 carry-over):** `claude-ai-service.ts` returns a 1536-length zero-vector from `generateEmbedding()` (placeholder until Voyage AI lands in a future story). Demo Solis Q&A still works because `searchSessions` uses *hybrid* ranking — keyword side surfaces results even with a null semantic vector. `seed-demo-client.ts` calls `aiService.generateEmbedding()` regardless and falls back to an explicit zero-vector on throw. Documented in code + tested.
+
+**Standalone Step 2B / Step 4B components:** Story 7.3 (which owns the onboarding shell + middleware redirect) ships AFTER 7.4 per the locked sequence. Per handoff instructions, Step 2B + Step 4B are built as standalone components with prop callbacks (`onContinue`, `onSkip`, `onExploreCard`, `onAskSolis`); 7.3 will wire them into the shell. They are not currently mounted anywhere — `/onboarding` still points at the legacy Story 1.8 flow, which 7.3 will delete and replace.
+
+**Demo content (BRAINSTORM §13 quality rubric):**
+- Persona: Alex Rivera, VP Engineering at Northridge Logistics (fictional mid-size logistics-tech company)
+- Theme arc: executive presence → preparation gap → all-hands breakthrough → peer-level influence
+- 4 sessions, ~3-month span (90/60/30/14 days before seed)
+- 8 action items, mix of completed + open, mix of coach + client assignees
+- Coach Brief: hand-written content matching `CoachBriefContent` shape
+- No real-company, no public-figure, no dated cultural references (test enforces blocklist)
+- All AI Strip fields are specific and grounded ("Executive presence — present in 3 of 4 sessions"; "Delivered the Q3 all-hands talk without retreating into technical detail")
+
+**Cost per signup:** ~$0.001 (4 embedding calls via OpenAI text-embedding-3-small). Brief = $0. Total negligible.
+
+**Demo badge on Client Card:** subtle outline chip next to client name (`text-foreground/55`), title-attr tooltip explains "Demo — explore MeetSolis with this sample client". Avoided large hero banner to keep Alex's card feeling like a real client.
+
+**"Re-add demo client" Settings CTA — SKIPPED per locked decision 2026-05-30.**
 
 ### Debug Log References
-_(to be filled by dev)_
+- `npx tsc --noEmit` → exit 0
+- `npx jest --testPathPattern "(lib/onboarding/__tests__/(demo-client-data|seed-demo-client)|api/onboarding/seed-demo/__tests__)"` → 3 suites / 23 tests pass
+- Wider Story 1.8 onboarding test suites (`OnboardingManager.test.ts`, `BrowserCompatibility.test.ts`, `DeviceTestingWizard.test.ts`) continue to pass — those tests will be deleted by Story 7.3 along with the legacy components
 
 ### File List
-_(to be filled by dev)_
+
+**New files:**
+- `apps/web/migrations/030_story_7_4_demo_client.sql`
+- `apps/web/migrations/031_story_7_4_demo_unique.sql` (post-QA — MAINT-002 fix)
+- `apps/web/src/lib/onboarding/demo-client-data.ts`
+- `apps/web/src/lib/onboarding/seed-demo-client.ts`
+- `apps/web/src/lib/onboarding/__tests__/demo-client-data.test.ts`
+- `apps/web/src/lib/onboarding/__tests__/seed-demo-client.test.ts`
+- `apps/web/src/app/api/onboarding/seed-demo/route.ts`
+- `apps/web/src/app/api/onboarding/seed-demo/__tests__/route.test.ts`
+- `apps/web/src/components/onboarding/steps/Step2BDemoTour.tsx`
+- `apps/web/src/components/onboarding/steps/Step4BCreateClient.tsx`
+- `apps/web/src/components/onboarding/steps/DemoBriefPreview.tsx`
+
+**Modified files:**
+- `packages/shared/src/schemas/client.ts` — exports `AIIntelligenceStripSchema` + `AIIntelligenceStrip` type; extends `ClientSchema` with `is_demo` + `ai_intelligence_strip`
+- `apps/web/src/app/(dashboard)/clients/[id]/page.tsx` — renders subtle "Demo" chip next to client name when `client.is_demo`
 
 ### Change Log
-_(to be filled by dev)_
+- 2026-05-30 — Initial implementation. Migration 030 (is_demo + ai_intelligence_strip; reuses existing coach_notes column from Story 6.4). Hand-written Alex Rivera demo content (4 sessions, 8 action items, AI strip, brief) in `demo-client-data.ts`. Idempotent seed function with embedding fallback. POST `/api/onboarding/seed-demo` Clerk-authed. Demo badge on Client Card. Step2BDemoTour + DemoBriefPreview + Step4BCreateClient as standalone components (Story 7.3 will mount). 23 unit/integration tests passing.
 
 ## QA Results
-_(to be filled by QA)_
+
+### Review Date: 2026-05-30
+
+### Reviewed By: Quinn (Test Architect)
+
+### Code Quality Assessment
+
+Clean execution against a story that had real architectural ambiguity (Pro-gated brief route vs Free coach in onboarding; `coach_note` → `coach_notes` column reuse vs new column). Dev made the right calls on both:
+- Built `DemoBriefPreview` as a Free-tier-safe mirror that reuses the seeded `coach_briefs` content for Pro coaches later
+- Reused existing `clients.coach_notes` from Story 6.4 instead of adding a duplicate column; propagated the rename to 7.2 + 7.7 specs
+
+Migration is idempotent and includes a partial index for the idempotency lookup. Seed function handles brief failure as non-fatal (correct — demo is still useful without a brief; coach can regenerate when Pro). Embedding fallback to zero-vector under the claude provider is documented and tested. Per-signup cost lands at the spec-stated ~$0.001.
+
+### Refactoring Performed
+
+None. Diff is appropriately scoped; refactoring would expand review scope.
+
+### Compliance Check
+
+- Coding Standards: ✓ Types shared via `@meetsolis/shared`. Zod on form input. No `any`. No direct `process.env`.
+- Project Structure: ✓ New API route under `app/api/onboarding/`. Demo data + seed under `lib/onboarding/`. Step components under `components/onboarding/steps/`.
+- Testing Strategy: ✗ Data layer well-covered (23/23 tests). UI components (Step2B, Step4B, DemoBriefPreview) have no mount tests yet — gap is small since they're currently unmounted.
+- All ACs Met: ✓ Every locked decision honored. Spec ACs that referenced the original `coach_note` plan are now historical text; deviation is documented in dev completion notes.
+
+### Improvements Checklist
+
+- [x] Verified migration 030 — additive, idempotent, partial index for idempotency lookup, well-commented
+- [x] Verified Zod schema extension exports `AIIntelligenceStripSchema` + type; extends `Client` with `is_demo` + `ai_intelligence_strip`
+- [x] Verified demo content blocklist (no real company / public figure / dated cultural reference); 4-session count; 3-month span; mix of completed + open + coach + client assignees
+- [x] Verified seed function idempotency, embedding fallback, non-fatal brief failure path
+- [x] Verified API route Clerk auth + standard error envelope
+- [x] Verified demo badge renders only when `client.is_demo`; Client Card page still under 500 lines (421)
+- [x] Re-ran tests: 23/23 pass across 3 suites; tsc exit 0
+- [x] Verified `coach_note` → `coach_notes` propagation in 7.2 + 7.7 specs
+- [x] **(MAINT-001, low — FIXED 2026-05-30)** Step2BDemoTour now uses `useMutation` from react-query; `buildDemoAIStrip()` and `buildDemoBriefContent()` wrapped in `useMemo`. Fires once on mount via `isIdle` guard. PERF-001 also addressed by the memo wrappers.
+- [x] **(MAINT-002, low — FIXED 2026-05-30)** Migration 031 adds `UNIQUE` partial index `uniq_clients_one_demo_per_user(user_id) WHERE is_demo = TRUE` (replaces non-unique 030 index). Seed function catches Postgres `23505` and re-fetches the winning row as `alreadySeeded`. New test covers the race-conflict path. **OPERATOR: apply migration 031 in Supabase.**
+- [x] **(SEC-001, low — FIXED 2026-05-30)** `INTERNAL_ERROR` client message is now generic ("Failed to set up your demo. Please try again."); full error stays in server logs. Test asserts no leak of "duplicate key" or constraint names.
+- [ ] **(TEST-001, future)** Add component mount tests for Step2BDemoTour, Step4BCreateClient, DemoBriefPreview to round out the testing pyramid.
+- [ ] **(PERF-001, future)** Memoize `buildDemoAIStrip()` and `buildDemoBriefContent()` calls in Step2BDemoTour with `useMemo`. Cosmetic.
+
+### Security Review
+
+- All routes Clerk-authed via `auth()` ✓
+- Internal user resolved via `getInternalUserId` ✓
+- No new attack surface beyond an authed seed-once endpoint
+- One low-severity finding: API echoes raw error messages back to caller (SEC-001 above). Acceptable for authed endpoint but worth tightening.
+
+### Performance Considerations
+
+- Per-signup cost ~$0.001 (4 OpenAI embeddings) — matches spec
+- Brief generation $0 (hand-written, deterministic insert)
+- Demo seed is one-shot; no ongoing load
+- Step 2B render-time recompute of demo data is wasted work but invisible (PERF-001 — defer)
+
+### Reliability Considerations
+
+- Brief-failure non-fatal path is correct
+- Idempotency check is correct but non-atomic — concurrent double-call window exists (MAINT-002)
+- Session/item insert failures throw fatally, leaving orphan client+earlier-sessions — acceptable for demo seed (low blast radius, deletable)
+
+### Files Modified During Review
+
+None.
+
+### Gate Status
+
+Gate: **PASS** → `docs/qa/gates/7.4-demo-client-path-b.yml`
+
+Quality score: **90/100** (three low-severity concerns: MAINT-001, MAINT-002, SEC-001)
+
+### Recommended Status
+
+✓ **Ready for Done** — All MUST items satisfied. The three open low-severity items (Step2B useMutation conversion, unique partial index, generic error message) are backlog-quality improvements, not ship blockers. MAINT-001 should ideally be addressed before Story 7.3 mounts the component live — flagging that handoff.

--- a/docs/stories/7.7.story.md
+++ b/docs/stories/7.7.story.md
@@ -12,7 +12,7 @@ Grounded against current `main`:
   - Action items section (7.6) is NOT yet built — leave a slot for it
   - Demo client (7.4) is shipped — `is_demo` badge works
   - Onboarding (7.3) NOT shipped — but unrelated; doesn't affect this story
-- **A2. `clients` already has** (per migrations 014 + 015 + 030): `id, user_id, name, company, role, goal, start_date, notes, overview, research_data, ai_intelligence_strip, coach_note, is_demo, created_at, updated_at, last_meeting_at`. Missing for this story:
+- **A2. (Updated 2026-05-30)** `clients` already has (per migrations 014 + 015 + 024 + Story 6.4 + Story 7.4 migration 030): `id, user_id, name, company, role, email, goal, start_date, notes, overview, research_data, coach_notes, ai_intelligence_strip, is_demo, created_at, updated_at, last_meeting_at`. Note: column is `coach_notes` (plural — from Story 6.4), NOT `coach_note`. Missing for this story:
   - `industry TEXT`
   - `company_size TEXT`
   - `about_notes TEXT`
@@ -233,7 +233,7 @@ Grounded against current `main`:
 - [ ] No `any` — extend types in `packages/shared`
 - [ ] No `process.env.*` direct
 - [ ] Zod on all PATCH/POST bodies
-- [ ] Sanitize text fields before render (XSS — `about_notes`, `coach_note`, etc.)
+- [ ] Sanitize text fields before render (XSS — `about_notes`, `coach_notes`, etc.)
 - [ ] Standard error handler
 - [ ] Tests:
   - Unit: monogram color is deterministic for same name

--- a/packages/shared/src/schemas/client.ts
+++ b/packages/shared/src/schemas/client.ts
@@ -5,6 +5,16 @@ import { z } from 'zod';
  * v3: Executive coach pivot — goal, start_date, notes replace email/phone/linkedin/tags/status
  */
 
+// Story 7.4 + 7.2 — AI-generated intelligence strip JSONB shape on clients.ai_intelligence_strip
+export const AIIntelligenceStripSchema = z.object({
+  recurring_theme: z.string(),
+  theme_frequency: z.string(),
+  recent_breakthrough: z.string(),
+  current_focus: z.string(),
+  generated_at: z.string(), // ISO timestamp
+});
+export type AIIntelligenceStrip = z.infer<typeof AIIntelligenceStripSchema>;
+
 // Base client schema with all fields
 export const ClientSchema = z.object({
   id: z.string().uuid(),
@@ -19,6 +29,10 @@ export const ClientSchema = z.object({
   notes: z.string().nullable().optional(),
   // Story 6.4 — private per-client coach notes, persists across sessions, never AI-touched
   coach_notes: z.string().nullable().optional(),
+  // Story 7.4 — Alex Rivera demo client flag
+  is_demo: z.boolean().default(false),
+  // Story 7.4 (seeded) / 7.2 (regen) — AI insight summary
+  ai_intelligence_strip: AIIntelligenceStripSchema.nullable().optional(),
   last_session_at: z.string().datetime().or(z.date()).nullable().optional(),
   created_at: z.string().datetime().or(z.date()),
   updated_at: z.string().datetime().or(z.date()),


### PR DESCRIPTION
## Summary

Story 7.4: seeded demo client "Alex Rivera" + Path B onboarding components (Step 2B demo tour, Step 4B manual client creation) + schema groundwork for Story 7.2.

**Key decisions baked in:**
- **Reuse `clients.coach_notes`** (Story 6.4) instead of duplicating with a new `coach_note` column. 7.2 + 7.7 specs propagated.
- **Hand-written brief content** in `demo-client-data.ts` → seeded into `coach_briefs` → real Story 6.4 component renders for Pro coaches. For Free coaches mid-onboarding, `DemoBriefPreview` mirrors the structure with the same content. **$0 per-signup brief cost.**
- ~$0.001 per signup (4 OpenAI embedding calls)

**QA gate:** PASS 90/100 → all three low-severity concerns fixed in-PR:
- **MAINT-001**: `Step2BDemoTour` now uses `useMutation` + `useMemo` (project CLAUDE.md convention)
- **MAINT-002**: Migration 031 adds `UNIQUE` partial index; seed function catches Postgres `23505` and re-fetches the winning row as `alreadySeeded`
- **SEC-001**: API returns generic error message; full detail in server logs only

**Tests:** 24/24 pass across 3 suites (was 23 — race-conflict test added). `tsc --noEmit` exit 0.

## Migrations

- **030**: `clients.is_demo` + `clients.ai_intelligence_strip` + partial index
- **031**: `UNIQUE` partial index `uniq_clients_one_demo_per_user` (MAINT-002 fix)

⚠️ **OPERATOR: apply migration 031 in Supabase before deploying.** Migration 030 was already applied during dev.

## Test plan

- [x] `npx tsc --noEmit` → exit 0
- [x] `npx jest --testPathPattern "(lib/onboarding/__tests__/(demo-client-data|seed-demo-client)|api/onboarding/seed-demo/__tests__)"` → 24/24 pass
- [x] QA gate → `docs/qa/gates/7.4-demo-client-path-b.yml`
- [ ] (Reviewer) Read Alex Rivera demo content in `demo-client-data.ts` — does it sound like an executive coach talking?
- [ ] (Reviewer) Apply migration 031 in staging Supabase before merge
- [ ] (Reviewer) Manual: POST `/api/onboarding/seed-demo` once (creates client), again (returns `alreadySeeded: true`)
- [ ] (Reviewer) Verify "Demo" chip renders on `/clients/{alexId}` for the seeded demo client

## Components shipped but unmounted

`Step2BDemoTour`, `Step4BCreateClient`, `DemoBriefPreview` are standalone — Story 7.3 (last in dev order) will wire them into the onboarding shell and add the first-login redirect. Until then, `/onboarding` still hosts the legacy Story 1.8 flow which 7.3 will delete + replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)